### PR TITLE
fix(playbooks): 修正跨平台断链、macOS-only 命令与 Windows Update 流程（A/6）

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ macOS / Linux：
 
 ## ❤️赞助商
 
-这里可以免费体验多种 AI 模型，例如 **Qwen3.8-Max-Preview**、**hy3**、**GLM-5.2**、**Kimi K3** 等。点击前往[免费 AI 福利指南](https://blog.88lin.eu.org/article/36)体验。
+这里可以免费体验多种主流大模型（通义千问、智谱 GLM、月之暗面 Kimi 等系列）。具体可用型号和额度会随上游调整，点击前往[免费 AI 福利指南](https://blog.88lin.eu.org/article/36)查看当前列表。
 
 ## 🧭 如何使用
 

--- a/skills/computer-repair-skill/SKILL.md
+++ b/skills/computer-repair-skill/SKILL.md
@@ -37,6 +37,14 @@ description: Use this skill when a user asks to diagnose, repair, clean up, reco
 - 读取 [playbook-index.md](references/playbook-index.md)，按症状、平台和触发词选择最具体的 Playbook。
 - 只加载当前任务需要的 `references/playbook-*.md`。不要一次读取全部 Playbook。
 - 优先选择精确 Playbook；多个问题确实独立时按影响和依赖顺序逐个执行。
+
+#### 平台路由硬规则
+
+- **绝不把用户路由进 `platform` 与其实际系统不符的 Playbook。** `platform: macos` 的 Playbook 不适用于 Windows 或 Linux 用户，即使其中的检查思路通用。
+- 存在同名平台变体时选择匹配的那一份，例如网络诊断按平台分为 `windows-network-diagnostics`、`network-diagnostics`（macOS）、`linux-network-diagnostics`；磁盘清理、性能取证同理。
+- `platform: all` 的 Playbook 内部仍可能只给出某一平台的命令。执行前确认当前步骤有本平台分支；没有时按 [tool-contract.md](references/tool-contract.md) 与平台映射文件翻译为等价的**只读**命令，并说明这是等价替代而非原文命令。
+- 当前平台确实没有对应 Playbook 时，不要降级到别的平台的 Playbook。改为执行本文件的通用工作流（只读诊断 → 计划 → 确认 → 最小变更 → 验证），并向用户说明缺少专项流程。
+- 翻译平台命令时保持风险等级不变：只读命令必须翻译成只读命令，不得用一个会改状态的命令替代只读检查。
 - 对含 `## Step N:` 的程序型 Playbook，按编号顺序推进并维护当前步骤。对诊断型 Playbook，沿其检查树执行。
 - Playbook 中的语义工具名不代表宿主必须存在同名工具；按工具契约进行映射。
 - 把 Playbook 视为诊断协议，不视为执行授权。当前系统事实、用户约束、宿主权限和本 Skill 的安全策略优先。
@@ -117,4 +125,4 @@ description: Use this skill when a user asks to diagnose, repair, clean up, reco
 
 ## 上游与许可
 
-本 Skill 包含 58 个可按需加载的 Playbook。上游项目、原作者归属和许可证记录在根目录 `NOTICE`；分发和修改时保留 `LICENSE` 与 `NOTICE`。
+本 Skill 包含一组可按需加载的 Playbook，完整清单和分类见 [playbook-index.md](references/playbook-index.md)。上游项目、原作者归属和许可证记录在根目录 `NOTICE`；分发和修改时保留 `LICENSE` 与 `NOTICE`。

--- a/skills/computer-repair-skill/references/playbook-backup-verify-restore.md
+++ b/skills/computer-repair-skill/references/playbook-backup-verify-restore.md
@@ -94,5 +94,7 @@ If verification reveals:
 - Backup is encrypted and password is unknown → this is a critical issue. The backup is unrecoverable. Document and escalate to the admin.
 
 ## Tools referenced
-- Shell commands — backup tool queries, file creation, restore commands
-- Disk usage tools — checking backup destination space
+- `shell_run` — query the platform backup tool, create the canary file, run the test restore
+- `win_disk_usage` / `mac_disk_usage` / `linux_disk_usage` — confirm the restore destination has free space
+- `ui_user_question` with `options` — confirm the restore target before anything is written
+- `ui_done` — report the verified restore with before/after evidence

--- a/skills/computer-repair-skill/references/playbook-backup-verify-restore.md
+++ b/skills/computer-repair-skill/references/playbook-backup-verify-restore.md
@@ -88,7 +88,7 @@ Remove any test files created during the verification:
 
 ## Escalation
 If verification reveals:
-- No backup tool installed → recommend setting one up immediately. Use the `setup-backup` playbook.
+- No backup tool installed → recommend setting one up immediately. On macOS use the `setup-backup` playbook. On Windows and Linux there is no equivalent playbook yet — instead confirm the platform's own options with the user (Windows: File History, OneDrive folder backup, or a third-party image tool; Linux: Timeshift for system snapshots plus restic/borg/rsync for data) and follow the same copy → verify → confirm sequence from this playbook.
 - Backup destination is full or inaccessible → the admin needs to provision more storage or fix the network path.
 - Restore test fails → the backup may be corrupted. Check backup logs, try restoring from an older snapshot, or reconfigure the backup.
 - Backup is encrypted and password is unknown → this is a critical issue. The backup is unrecoverable. Document and escalate to the admin.

--- a/skills/computer-repair-skill/references/playbook-browser-security-audit.md
+++ b/skills/computer-repair-skill/references/playbook-browser-security-audit.md
@@ -77,5 +77,7 @@ If sideloaded extensions with broad permissions are found and the user didn't in
 - If on a corporate device, notify IT — policy-managed extensions should come from a known source.
 
 ## Tools referenced
-- Shell commands — read browser config files, check update agents
-- Disk audit tools — check browser profile sizes
+- `shell_run` — read browser configuration files and check update agents
+- `win_app_data_ls` / `mac_app_support_ls` — locate browser profile directories
+- `win_disk_usage` / `mac_disk_usage` / `linux_disk_usage` — measure browser profile sizes
+- `ui_info` — report findings; this playbook is read-only and never removes an extension itself

--- a/skills/computer-repair-skill/references/playbook-credential-cleanup.md
+++ b/skills/computer-repair-skill/references/playbook-credential-cleanup.md
@@ -86,5 +86,7 @@ If the cleanup is for a security incident:
 - If the device may be compromised, a full wipe may be more appropriate than selective cleanup. Consult IT security.
 
 ## Tools referenced
-- Shell commands — keychain queries, klist, SSH key listing
-- User confirmation prompts — confirmation before each removal action
+- `shell_run` — keychain / Credential Manager queries, `klist`, SSH key listing (names and paths only)
+- `ui_user_question` with `options` — confirm each credential store separately before touching it
+- `ui_info` — report what exists without printing any secret value
+- `ui_done` — summarize what was cleared and what still needs manual rotation

--- a/skills/computer-repair-skill/references/playbook-dns-record-check.md
+++ b/skills/computer-repair-skill/references/playbook-dns-record-check.md
@@ -76,5 +76,6 @@ If DNS records look correct but email delivery still fails:
 - If the domain is on a blocklist, escalate to the domain administrator for delisting.
 
 ## Tools referenced
-- DNS lookup tools — DNS lookups for MX, TXT, and other record types
-- User input prompts — collect domain name and DKIM selector
+- `win_dns_check` / `mac_dns_check` / `linux_dns_check` — DNS lookups for MX, TXT, and other record types
+- `ui_user_question` with `text_input` — collect domain name and DKIM selector
+- `ui_info` — present the record table and what each missing record implies

--- a/skills/computer-repair-skill/references/playbook-email-connectivity-test.md
+++ b/skills/computer-repair-skill/references/playbook-email-connectivity-test.md
@@ -19,7 +19,7 @@ User can't send or receive email, email client shows connection errors, suspecte
 
 ### 1. Test DNS resolution of mail server
 If the user has a specific mail server, resolve it first using a DNS lookup.
-- If DNS fails, email won't work regardless of port connectivity. Activate the `network-diagnostics` playbook to fix DNS first.
+- If DNS fails, email won't work regardless of port connectivity. Activate the platform-matched networking playbook to fix DNS first — `windows-network-diagnostics` (Windows), `network-diagnostics` (macOS), or `linux-network-diagnostics` (Linux).
 - If no specific server, skip to step 2 and test common providers.
 
 ### 2. Test SMTP connectivity
@@ -28,7 +28,17 @@ Test connectivity to common SMTP ports:
 - **Port 465** (SMTP over SSL) — legacy but still used by some providers.
 - **Port 587** (SMTP submission with STARTTLS) — the standard port for sending email. This one matters most.
 
-Use an HTTP check or `nc -z -w 5 <host> <port>` to test. Report which ports are reachable.
+Use a platform-appropriate TCP reachability check — `nc` does not exist on a stock
+Windows install, and is not guaranteed on a minimal Linux either:
+
+| Platform | Command |
+|---|---|
+| Windows | `Test-NetConnection -ComputerName <host> -Port <port> -InformationLevel Quiet` |
+| macOS | `nc -z -w 5 <host> <port>` |
+| Linux | `nc -z -w 5 <host> <port>`; if netcat is absent, `timeout 5 bash -c '</dev/tcp/<host>/<port>'` and check the exit code |
+
+All three are read-only reachability probes: they open a TCP connection and close
+it without authenticating or sending mail. Report which ports are reachable.
 
 ### 3. Test IMAP and POP3 connectivity
 - **Port 993** (IMAP over SSL) — standard for receiving email with IMAP.
@@ -81,7 +91,8 @@ If all ports are blocked:
 - If the problem persists across networks, check for local firewall software (Little Snitch, Windows Firewall rules).
 
 ## Tools referenced
-- DNS lookup tools — resolve mail server hostnames
-- HTTP check tools — test HTTPS connectivity to web endpoints
-- Shell commands — test TCP connectivity to specific ports via `nc`
-- Ping tools — basic reachability check
+- `win_dns_check` / `mac_dns_check` / `linux_dns_check` — resolve mail server hostnames
+- `win_http_check` / `mac_http_check` / `linux_http_check` — test HTTPS connectivity to web endpoints
+- `shell_run` — TCP port reachability (`Test-NetConnection` on Windows, `nc` on macOS/Linux)
+- `win_ping` / `mac_ping` / `linux_ping` — basic reachability check
+- `ui_info` — present the host/port/status table

--- a/skills/computer-repair-skill/references/playbook-endpoint-security-check.md
+++ b/skills/computer-repair-skill/references/playbook-endpoint-security-check.md
@@ -84,5 +84,7 @@ If suspicious network connections or unrecognized processes are found:
 - Persistent red findings after remediation suggest a deeper compromise — recommend professional incident response.
 
 ## Tools referenced
-- Shell commands — check firewall, list processes, network connections
-- Process listing tools — find running AV/endpoint protection processes
+- `shell_run` — read firewall state, list listening ports, query update status
+- `win_process_list` / `mac_process_list` / `linux_process_list` — find running AV/endpoint protection processes
+- `win_service_list` — check Defender, firewall and update service state on Windows
+- `ui_info` — report findings; never disable a protection component to "test" it

--- a/skills/computer-repair-skill/references/playbook-health-baseline-check.md
+++ b/skills/computer-repair-skill/references/playbook-health-baseline-check.md
@@ -2,7 +2,7 @@
 name: health-baseline-check
 description: Comprehensive device health check — disk, memory, uptime, updates, firewall, backup, and network
 platform: all
-last_reviewed: 2026-03-17
+last_reviewed: 2026-07-28
 author: upstream-maintainers
 source: bundled
 emoji: 🩺
@@ -17,46 +17,79 @@ New device setup, periodic health audit, pre-migration baseline, user reports ge
 
 ## Standard check path
 
+> **Platform routing.** Every step below has a command for all three platforms.
+> Detect the actual OS first (see SKILL.md "执行前检查") and run only that
+> platform's branch. Never hand a macOS-only command to a Windows or Linux user.
+
 ### 1. Check disk space
-Check overall disk stats.
+Check overall disk stats with `win_disk_usage` / `mac_disk_usage` / `linux_disk_usage`.
 - **Green**: <80% used.
-- **Yellow**: 80-90% used. Mention the `disk-space-recovery` playbook.
+- **Yellow**: 80-90% used. Mention the platform-matched cleanup playbook:
+  `windows-disk-space-recovery` (Windows), `disk-space-recovery` (macOS),
+  `linux-disk-space-recovery` (Linux).
 - **Red**: >90% used. SSDs degrade above 90%. Flag for immediate cleanup.
 
 ### 2. Check memory usage
 Check RAM usage using system memory info.
 - Report total RAM, used, and available.
+- **Windows**: `Get-CimInstance Win32_OperatingSystem | Select-Object TotalVisibleMemorySize, FreePhysicalMemory`; commit charge via `Get-Counter '\Memory\% Committed Bytes In Use'`.
+- **macOS**: `vm_stat` plus memory pressure — `memory_pressure -Q` if available.
+- **Linux**: `free -h` and `cat /proc/pressure/memory` (PSI, kernel 4.20+).
 - **Green**: >20% available.
 - **Yellow**: 10-20% available. Check what's consuming memory.
 - **Red**: <10% available or heavy swap usage. Identify top consumers.
 
 ### 3. Check system uptime
-Run `uptime` to check how long since last reboot.
+- **Windows**: `(Get-CimInstance Win32_OperatingSystem).LastBootUpTime` — there is no `uptime` command in PowerShell. Also check for fast startup masking a "restart": `powercfg /a`.
+- **macOS / Linux**: `uptime`.
 - **Green**: <14 days.
 - **Yellow**: 14-30 days. Suggest a restart — many updates and fixes require a reboot.
 - **Red**: >30 days. Strongly recommend a restart.
 
 ### 4. Check OS version and update status
-- Report the current OS version.
-- Run `softwareupdate --list` (macOS) to check for pending updates.
+Report the current OS version, then check for pending updates read-only.
+
+- **Windows**:
+  - Version: `Get-ComputerInfo | Select-Object OsName, OsVersion, OsBuildNumber`.
+  - Last patches: `Get-HotFix | Sort-Object InstalledOn -Descending | Select-Object -First 5`.
+  - Pending updates (read-only search, no install):
+    `(New-Object -ComObject Microsoft.Update.Session).CreateUpdateSearcher().Search("IsInstalled=0 AND IsHidden=0").Updates | Select-Object Title, IsMandatory`
+- **macOS**: `sw_vers` for version, `softwareupdate --list` for pending updates.
+- **Linux**:
+  - Version: `cat /etc/os-release`, `uname -r`.
+  - Debian/Ubuntu: `apt list --upgradable` (reflects the last metadata refresh — say so); Ubuntu security count: `/usr/lib/update-notifier/apt-check --human-readable`.
+  - Fedora/RHEL: `dnf check-update` (exit code 100 means updates are available — not a failure).
+  - Arch: `checkupdates` from `pacman-contrib`.
+
 - **Green**: up to date.
 - **Yellow**: non-security updates pending.
 - **Red**: security updates pending.
 
 ### 5. Check firewall status
-- **macOS**: Check `defaults read /Library/Preferences/com.apple.alf globalstate`.
-- **Green**: firewall enabled (value 1 or 2).
-- **Red**: firewall disabled (value 0). Recommend enabling it.
+- **Windows**: `Get-NetFirewallProfile | Select-Object Name, Enabled` — all three profiles (Domain/Private/Public) should be `True`.
+- **macOS**: `defaults read /Library/Preferences/com.apple.alf globalstate` — 1 or 2 means enabled, 0 means disabled.
+- **Linux**: whichever front end is actually in use — `ufw status`, `firewall-cmd --state`, `nft list ruleset`, or `iptables -S` (most need root). Confirm which one is active first with `systemctl is-active ufw firewalld nftables`.
+- **Green**: firewall enabled.
+- **Red**: firewall disabled. Recommend enabling it.
+- Report the finding; **do not disable a firewall** and do not silently enable one — enabling can break LAN printing, file shares, or remote access. Confirm with the user first.
 
 ### 6. Check backup status
-- **macOS**: Check Time Machine status via `tmutil status` and `tmutil latestbackup`.
+- **Windows**: there is no single canonical backup mechanism — check several and report what exists:
+  - Restore points: `Get-ComputerRestorePoint`.
+  - File History service: `Get-Service -Name fhsvc`.
+  - OneDrive folder backup: `$env:OneDrive` and `Get-Process OneDrive -ErrorAction SilentlyContinue`.
+  - Image backup (admin, not present on all editions): `wbadmin get versions`.
+- **macOS**: `tmutil status` and `tmutil latestbackup`.
+- **Linux**: also no canonical mechanism — check `systemctl list-timers` for backup timers, `timeshift --list` (root), and scheduled jobs via `crontab -l` and `ls /etc/cron.*`.
 - Report when the last backup completed.
 - **Green**: backup within the last 24 hours.
 - **Yellow**: backup is 1-7 days old.
 - **Red**: no backup configured, or last backup is older than 7 days.
 
 ### 7. Check network connectivity
-Run the quick connectivity checks from the `network-diagnostics` playbook:
+Run the quick connectivity checks from the platform-matched networking playbook —
+`windows-network-diagnostics` (Windows), `network-diagnostics` (macOS), or
+`linux-network-diagnostics` (Linux):
 - Ping `8.8.8.8` — basic internet.
 - DNS check for `google.com` — DNS working.
 - HTTP check for `https://www.google.com` — full connectivity.
@@ -83,7 +116,10 @@ Give an overall assessment: healthy, needs attention, or needs immediate action.
 - This is a point-in-time snapshot. Conditions change — memory usage fluctuates, network can be intermittent.
 - **"Purgeable" disk space** on macOS is technically available. Don't flag disk as critical if most of the used space is purgeable.
 - **High memory usage isn't always bad.** macOS aggressively caches files in RAM. "Memory pressure" is a better indicator than raw usage. Check for swap usage as the real signal.
-- **No Time Machine** isn't necessarily a problem if the user uses another backup solution (Backblaze, CrashPlan, iCloud). Ask before flagging.
+- **No Time Machine** isn't necessarily a problem if the user uses another backup solution (Backblaze, CrashPlan, iCloud). Ask before flagging. The same applies to Windows and Linux, where there is no single expected backup tool at all.
+- **Windows update search needs the Windows Update service running.** If `wuauserv` is stopped or a WSUS/MDM policy redirects it, the read-only search returns nothing — that is not the same as "up to date". Check `Get-Service wuauserv` before concluding.
+- **`apt list --upgradable` reads cached metadata.** Without a recent `apt update` (which needs root and network) the list can be stale. Report the cache age instead of implying a live check.
+- **Uptime on Windows is not reboot count.** Fast startup and hibernate can keep `LastBootUpTime` old even though the user "shut down" daily; a Shift-restart or `shutdown /r /t 0` is the real reboot.
 
 > The full baseline covers ~90% of common device health issues. Most frequent finding: pending OS updates and stale backups.
 
@@ -100,9 +136,11 @@ If multiple categories are red:
 - If the device is consistently unhealthy, it may need a fresh OS install or hardware evaluation.
 
 ## Tools referenced
-- Disk usage tools — disk space stats
-- Memory info tools — RAM usage
-- Shell commands — uptime, firewall check, softwareupdate
-- DNS lookup tools — DNS connectivity
-- HTTP check tools — HTTP connectivity
-- Ping tools — basic network check
+- `win_disk_usage` / `mac_disk_usage` / `linux_disk_usage` — disk space stats
+- `win_system_info` / `mac_system_info` / `linux_system_info` — OS version, RAM, uptime
+- `shell_run` — uptime, firewall state, update search, backup state (read-only)
+- `win_service_list` — Windows Update and File History service state
+- `win_dns_check` / `mac_dns_check` / `linux_dns_check` — DNS connectivity
+- `win_http_check` / `mac_http_check` / `linux_http_check` — HTTP connectivity
+- `win_ping` / `mac_ping` / `linux_ping` — basic network check
+- `ui_done` — final baseline summary after all checks complete

--- a/skills/computer-repair-skill/references/playbook-identity-provider-test.md
+++ b/skills/computer-repair-skill/references/playbook-identity-provider-test.md
@@ -2,7 +2,7 @@
 name: identity-provider-test
 description: Test connectivity to identity providers — Microsoft Entra ID, Google Workspace, and SSO endpoints
 platform: all
-last_reviewed: 2026-03-17
+last_reviewed: 2026-07-28
 author: upstream-maintainers
 source: bundled
 emoji: 🪪
@@ -19,7 +19,7 @@ User can't sign in to corporate services, SSO failures, "session expired" loops,
 
 ### 1. Test Microsoft Entra ID (M365) DNS
 Resolve `login.microsoftonline.com` using a DNS lookup.
-- If resolution fails, DNS is broken — activate `network-diagnostics` first.
+- If resolution fails, DNS is broken — activate the platform-matched networking playbook first: `windows-network-diagnostics` (Windows), `network-diagnostics` (macOS), or `linux-network-diagnostics` (Linux).
 - If it resolves to an unexpected IP or a local IP, a proxy or DNS filter may be intercepting authentication traffic.
 
 ### 2. Test Google Workspace DNS
@@ -79,7 +79,8 @@ If IdP endpoints are reachable but authentication still fails:
 - If the IdP itself is down (returns 5xx), check the provider's status page and wait.
 
 ## Tools referenced
-- DNS lookup tools — resolve IdP hostnames
-- HTTP check tools — test HTTPS connectivity to login endpoints
-- Network info tools — check for VPN interfaces
-- Shell commands — check proxy settings, time sync, VPN status
+- `win_dns_check` / `mac_dns_check` / `linux_dns_check` — resolve identity provider hostnames
+- `win_http_check` / `mac_http_check` / `linux_http_check` — test HTTPS reachability of login endpoints
+- `win_network_info` / `mac_network_info` / `linux_network_info` — detect VPN interfaces and proxy configuration
+- `shell_run` — check clock skew (`w32tm /query /status`, `sntp -d`, `timedatectl`) and proxy settings
+- `ui_info` — report which providers are reachable and whether the fault is network- or account-level

--- a/skills/computer-repair-skill/references/playbook-local-data-audit.md
+++ b/skills/computer-repair-skill/references/playbook-local-data-audit.md
@@ -2,7 +2,7 @@
 name: local-data-audit
 description: Audit a device for locally stored sensitive or company data — for offboarding or device reassignment
 platform: all
-last_reviewed: 2026-03-17
+last_reviewed: 2026-07-28
 author: upstream-maintainers
 source: bundled
 emoji: 📂
@@ -17,20 +17,40 @@ Scans the device for locally stored company data, personal files, and sensitive 
 ## When to activate
 Employee offboarding, device reassignment, compliance audit, or when verifying that company data has been properly backed up before a wipe.
 
+## Platform path map
+
+Resolve the home directory and per-platform locations before scanning. `~` below
+means the real home directory on each platform — do not paste POSIX paths into a
+Windows shell.
+
+| Target | Windows | macOS | Linux |
+|---|---|---|---|
+| Home | `$env:USERPROFILE` | `~` | `~` |
+| Documents / Desktop / Downloads | `$env:USERPROFILE\Documents` etc. (may be redirected into OneDrive) | `~/Documents` etc. | `~/Documents` etc. (localized names live in `~/.config/user-dirs.dirs`) |
+| Per-user app data | `$env:LOCALAPPDATA`, `$env:APPDATA` | `~/Library/Application Support`, `~/Library/Containers` | `~/.config`, `~/.local/share`, `~/.var/app` (Flatpak) |
+| SSH keys | `$env:USERPROFILE\.ssh` | `~/.ssh` | `~/.ssh` |
+| OS credential store | Credential Manager — list names only via `cmdkey /list` | Keychain — `security dump-keychain` is **not** allowed here; list items only | Secret Service / `~/.local/share/keyrings` — do not read |
+
 ## Standard check path
 
 ### 1. Check user profile directories
 Scan the user's home directory for document-like files:
-- Count files by type in `~/Documents`, `~/Desktop`, `~/Downloads`.
+- Count files by type in the Documents / Desktop / Downloads paths from the table above.
 - Report total size and file count for each directory.
 - Flag large files (>100MB) that may need special handling.
+- **Windows**: check for Known Folder redirection first — if Desktop/Documents point into OneDrive, the "local" data is already synced. `Get-ItemProperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders'`.
+- **Linux**: user directories may be localized (`~/Documentos`). Read `~/.config/user-dirs.dirs` instead of assuming English names.
 
 ### 2. Check cloud sync status
 Determine if the user has cloud storage synced locally:
-- **OneDrive**: Check for `~/OneDrive` or `~/Library/CloudStorage/OneDrive*`.
-- **Google Drive**: Check for `~/Google Drive` or `~/Library/CloudStorage/GoogleDrive*`.
-- **Dropbox**: Check for `~/Dropbox` or `~/.dropbox`.
-- **iCloud**: Check for `~/Library/Mobile Documents`.
+
+| Service | Windows | macOS | Linux |
+|---|---|---|---|
+| OneDrive | `$env:OneDrive`, `$env:USERPROFILE\OneDrive*` | `~/Library/CloudStorage/OneDrive*` | rarely present (third-party clients such as `onedriver`, `rclone`) |
+| Google Drive | `$env:USERPROFILE\My Drive`, `G:\` virtual drive | `~/Library/CloudStorage/GoogleDrive*`, `~/Google Drive` | `rclone` mounts, `google-drive-ocamlfuse` |
+| Dropbox | `$env:USERPROFILE\Dropbox`, `$env:LOCALAPPDATA\Dropbox` | `~/Dropbox`, `~/.dropbox` | `~/Dropbox`, `~/.dropbox` |
+| iCloud Drive | `$env:USERPROFILE\iCloudDrive` | `~/Library/Mobile Documents` | not supported |
+| Nextcloud / Syncthing | `$env:USERPROFILE\Nextcloud` | `~/Nextcloud` | `~/Nextcloud`, `~/Sync` |
 
 Report which services are synced and their local folder sizes. Synced data is generally safe (exists in the cloud), but confirm before removing.
 
@@ -38,22 +58,28 @@ Report which services are synced and their local folder sizes. Synced data is ge
 Search for files that commonly contain sensitive data:
 - Files with names containing: `password`, `credential`, `secret`, `key`, `token`, `.env`, `config`.
 - Files with extensions: `.pem`, `.key`, `.pfx`, `.p12`, `.kdbx` (password databases).
-- Check `~/.ssh/` for private keys.
+- Check the SSH key path from the table above for private keys.
+- **Windows also**: `cmdkey /list` (names only, never values), `$env:APPDATA\Microsoft\Crypto` for DPAPI material, `certutil -store -user My` for user certificates with private keys.
+- **macOS also**: `~/Library/Keychains` presence and size; `~/.aws`, `~/.kube`, `~/.docker/config.json`.
+- **Linux also**: `~/.gnupg`, `~/.aws`, `~/.kube`, `~/.docker/config.json`, `~/.netrc`, `~/.pgpass`.
 - Check for database files (`.db`, `.sqlite`) in common locations.
 
-Report found files with paths and sizes. Do not read or display file contents.
+Report found files **with paths, sizes and timestamps only**. Do not read, decrypt, or display file contents — the existence of a key is the finding.
 
 ### 4. Check application data
-Look for locally stored application data that may contain company information:
-- Email client local cache/storage size (Outlook, Thunderbird, Apple Mail).
-- Chat application data (Slack, Teams, Zoom).
-- Browser profiles with bookmarks and history.
+Look for locally stored application data that may contain company information. Report **sizes and paths only**, never contents.
 
-Report which applications have significant local data stores.
+| App class | Windows | macOS | Linux |
+|---|---|---|---|
+| Email | `$env:LOCALAPPDATA\Microsoft\Outlook` (`.ost`/`.pst`), `$env:APPDATA\Thunderbird` | `~/Library/Group Containers/*.Office`, `~/Library/Mail` | `~/.thunderbird`, `~/.local/share/evolution` |
+| Chat | `$env:APPDATA\Slack`, `$env:APPDATA\Microsoft\Teams` | `~/Library/Application Support/Slack` / `Microsoft/Teams` | `~/.config/Slack`, `~/.config/Microsoft/Microsoft Teams` |
+| Browser profiles | `$env:LOCALAPPDATA\Google\Chrome\User Data`, `...\Microsoft\Edge\User Data`, `$env:APPDATA\Mozilla\Firefox` | `~/Library/Application Support/Google/Chrome`, `~/Library/Safari` | `~/.config/google-chrome`, `~/.mozilla/firefox` |
+
+Report which applications have significant local data stores. Do not open cookie stores, chat databases, or saved-password stores — that is out of scope for an offboarding size audit.
 
 ### 5. Check for code repositories
 Search for git repositories that may contain company code:
-- Look for `.git` directories in common locations (`~`, `~/src`, `~/code`, `~/projects`, `~/repos`, `~/dev`, `~/work`).
+- Look for `.git` directories in common locations (home, `src`, `code`, `projects`, `repos`, `dev`, `work`). On Windows also check `C:\dev`, `C:\src` and any WSL distro home via `\\wsl$\<distro>\home\<user>`.
 - Report repository names and sizes.
 - Note: code repos often contain credentials in config files or `.env` — flag these.
 
@@ -88,5 +114,8 @@ If the audit reveals:
 - If the user is uncooperative or the device may be tampered with — involve IT security for supervised data collection.
 
 ## Tools referenced
-- Shell commands — file listing, directory size calculation, find/search
-- Disk usage tools — checking folder sizes
+- `shell_run` — file listing, directory size calculation, find/search (read-only)
+- `win_disk_usage` / `mac_disk_usage` / `linux_disk_usage` — checking folder sizes
+- `win_app_data_ls` / `mac_app_support_ls` — enumerate per-app data directories by size, metadata only
+- `win_path_inventory` — Windows path/size/timestamp inventory without reading contents
+- `ui_info` — report the audit table without asserting a cleanup decision

--- a/skills/computer-repair-skill/references/playbook-mac-tune-up.md
+++ b/skills/computer-repair-skill/references/playbook-mac-tune-up.md
@@ -108,3 +108,4 @@ If the Mac is still slow after the sweep:
 - `shell_run` — runs each maintenance command (safe / sudo-gated tier)
 - `mac_system_info`, `vm_stat` — before/after measurement
 - `mac_disk_usage` — confirm this isn't actually a disk-full case first
+- `ui_done` — final summary with memory reclaimed per step

--- a/skills/computer-repair-skill/references/playbook-performance-forensics.md
+++ b/skills/computer-repair-skill/references/playbook-performance-forensics.md
@@ -111,6 +111,7 @@ rather than failing the flow. Don't assume a specific macOS version.
 - `shell_run` — `sudo purge` (memory relief)
 - `mac_system_info` / `mac_process_list` / `mac_disk_usage` — only if you need
   raw detail the diagnose tool didn't surface
+- `ui_done` — report the verified before/after result
 
 ## Escalation
 If performance is still poor after diagnosis:

--- a/skills/computer-repair-skill/references/playbook-setup-backup.md
+++ b/skills/computer-repair-skill/references/playbook-setup-backup.md
@@ -46,5 +46,6 @@ Confirm the first backup has started and show estimated time.
 
 ## Tools referenced
 - `shell_run` — tmutil commands
-- `ui_user_question` — backup destination choice, exclusion paths
+- `ui_user_question` with options — backup destination choice
+- `ui_user_question` with `text_input` — exclusion paths
 - `ui_spa` with WAIT_FOR_USER — plugging in drives

--- a/skills/computer-repair-skill/references/playbook-setup-openclaw-config-reference.md
+++ b/skills/computer-repair-skill/references/playbook-setup-openclaw-config-reference.md
@@ -216,3 +216,12 @@ openclaw logs --follow             # real-time logs
 openclaw status                    # overall system status
 openclaw dashboard                 # open Control UI in browser
 ```
+
+## Tools referenced
+- `shell_run` — `openclaw config get/set/unset`, `openclaw doctor`, gateway and channel status
+- `win_read_file` / `mac_read_file` / `linux_read_file` — inspect `config.json` and included fragments directly
+- `ui_info` — explain a field, its default and its blast radius without changing anything
+
+This is a reference document, not a procedure. Read a value before writing it, and
+route any actual change through `setup-openclaw-configure` so the confirm-and-verify
+steps are not skipped.

--- a/skills/computer-repair-skill/references/playbook-setup-openclaw-uninstall.md
+++ b/skills/computer-repair-skill/references/playbook-setup-openclaw-uninstall.md
@@ -2,7 +2,7 @@
 name: setup-openclaw/uninstall
 description: Completely uninstall OpenClaw — stop services, remove config, uninstall CLI
 platform: all
-last_reviewed: 2026-03-10
+last_reviewed: 2026-07-28
 author: upstream-maintainers
 source: bundled
 emoji: 🦞
@@ -30,21 +30,45 @@ Ask the user to confirm they want to completely remove OpenClaw. Explain:
 Use `ui_user_question` with options: **Yes, uninstall everything** / **Cancel**.
 If the user cancels, use `ui_done` and stop.
 
-## Step 2: Remove Everything
+## Step 2: Offer a config snapshot before deleting
+
+Deleting the state directory is irreversible, and users who "uninstall" often
+still want their channel and model configuration back later. Before Step 3, offer
+to copy the config out:
+
+- **Windows**: `Copy-Item -Recurse "$env:USERPROFILE\.openclaw" "$env:USERPROFILE\Desktop\openclaw-config-backup-$(Get-Date -Format yyyyMMdd)"`
+- **macOS / Linux**: `cp -a ~/.openclaw ~/Desktop/openclaw-config-backup-$(date +%Y%m%d)`
+
+Then verify the copy exists and is non-empty before anything is removed. Warn the
+user that the snapshot may contain API keys and tokens — it should be treated as a
+secret and deleted once no longer needed. Do not print its contents.
+
+If the user declines, record that they declined and continue.
+
+## Step 3: Remove Everything
 
 Execute all cleanup operations in this single step. Show progress via `ui_spa`
 with `action_type: "RUN_STEP"` as you work through each sub-task.
 
-### 2a. Stop and remove gateway service
+### 3a. Stop and remove gateway service
 
 First check if the `openclaw` CLI is available:
-Run `shell_run` with `which openclaw`.
+- **Windows**: `Get-Command openclaw -ErrorAction SilentlyContinue`
+- **macOS / Linux**: `which openclaw`
 
 **If CLI is available (easy path):**
 Run `shell_run` with `openclaw gateway stop`. Ignore errors (may already be stopped).
 Run `shell_run` with `openclaw gateway uninstall`. Ignore errors.
 
 **If CLI is NOT available (manual path):**
+
+On Windows — discover what actually exists rather than assuming a mechanism:
+- Scheduled task: `Get-ScheduledTask -TaskName '*openclaw*' -ErrorAction SilentlyContinue`
+- Service: `Get-Service -Name '*openclaw*' -ErrorAction SilentlyContinue`
+- Startup entry: `Get-ItemProperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' | Select-Object openclaw*`
+- Stop and remove only the entries that were found, one at a time, and show the
+  user each one first: `Stop-ScheduledTask`, then `Unregister-ScheduledTask -Confirm:$false`.
+- Live process check: `Get-Process -Name '*openclaw*' -ErrorAction SilentlyContinue`
 
 On macOS:
 - Check for service: `launchctl list | grep openclaw`
@@ -57,51 +81,79 @@ On Linux:
 - Remove unit file: `rm -f ~/.config/systemd/user/openclaw-gateway.service`
 - Reload: `systemctl --user daemon-reload`
 
-### 2b. Delete configuration and state
+### 3b. Delete configuration and state
 
-The main state directory is `~/.openclaw` (or `$OPENCLAW_STATE_DIR` if set).
+The main state directory is `.openclaw` in the user's home (or `OPENCLAW_STATE_DIR`
+if that variable is set — check it first on every platform).
 
-Run `shell_run` with `rm -rf ~/.openclaw`.
+**List before deleting** so the user sees what is going away:
+- **Windows**: `Get-ChildItem "$env:USERPROFILE\.openclaw" -Force | Select-Object Name, Length, LastWriteTime`
+- **macOS / Linux**: `ls -la ~/.openclaw`
+
+Then remove it:
+- **Windows**: `Remove-Item -Recurse -Force "$env:USERPROFILE\.openclaw"`
+- **macOS / Linux**: `rm -rf ~/.openclaw`
+
 This removes config, state, workspace, and all stored data.
 
 Also check for multi-profile directories (legacy feature):
-Run `shell_run` with `ls -d ~/.openclaw-* 2>/dev/null || echo "none"`.
-If any exist, delete each one: `rm -rf ~/.openclaw-*`.
+- **Windows**: `Get-ChildItem "$env:USERPROFILE" -Directory -Filter '.openclaw-*' -Force`
+- **macOS / Linux**: `ls -d ~/.openclaw-* 2>/dev/null || echo "none"`
 
-### 2c. Uninstall CLI
+If any exist, delete each one explicitly by its literal path. Do not run a
+recursive delete against a wildcard the user has not seen expanded.
 
-Try each package manager in order (only one will have it installed):
+### 3c. Uninstall CLI
 
-1. npm: `npm list -g openclaw 2>/dev/null && npm rm -g openclaw`
-2. pnpm: `pnpm list -g openclaw 2>/dev/null && pnpm remove -g openclaw`
-3. bun: `bun remove -g openclaw 2>/dev/null`
+Try each package manager in order (only one will have it installed). These commands
+are identical on all three platforms:
+
+1. npm: `npm list -g openclaw` then `npm rm -g openclaw`
+2. pnpm: `pnpm list -g openclaw` then `pnpm remove -g openclaw`
+3. bun: `bun remove -g openclaw`
 
 If none succeed, warn the user the CLI may need manual removal.
 
-Verify removal: `which openclaw` should return "not found".
+Verify removal:
+- **Windows**: `Get-Command openclaw -ErrorAction SilentlyContinue` should return nothing.
+- **macOS / Linux**: `which openclaw` should return "not found".
 
-### 2d. Remove desktop app (macOS only)
+On Windows also check for a stale shim left behind in
+`$env:APPDATA\npm` — npm global bin shims (`openclaw.cmd`, `openclaw.ps1`) sometimes
+survive an uninstall and keep the command "working" while pointing at nothing.
 
-On macOS, check for the desktop app:
-Run `shell_run` with `ls /Applications/OpenClaw.app 2>/dev/null || echo "not found"`.
-If it exists: `rm -rf /Applications/OpenClaw.app`.
+### 3d. Remove desktop app
 
-Skip on Linux (no desktop app).
+- **macOS**: check for the desktop app with `ls /Applications/OpenClaw.app 2>/dev/null || echo "not found"`. If it exists: `rm -rf /Applications/OpenClaw.app`. Also check `~/Applications`.
+- **Windows**: verify whether a desktop build is even installed before acting — `winget list --name OpenClaw`, `Get-ChildItem "$env:LOCALAPPDATA\Programs" -Filter '*OpenClaw*'`, and Start Menu shortcuts under `$env:APPDATA\Microsoft\Windows\Start Menu\Programs`. If an installer entry exists, uninstall through it (`winget uninstall`) rather than deleting the program directory.
+- **Linux**: skip — no desktop app. Also check `~/.local/share/applications` for a stale `.desktop` launcher if one was created manually.
 
-## Step 3: Done
+Confirm the current OpenClaw release actually ships a build for the user's platform
+before promising removal steps for it; this list follows what upstream documented at
+`last_reviewed` time.
+
+## Step 4: Done
 
 Show a done card summarizing what was removed:
+- Config snapshot: saved to `<path>` / declined by user
 - Gateway service: stopped and removed
-- Configuration: `~/.openclaw/` deleted
+- Configuration: state directory deleted
 - Multi-profile directories: cleaned (if any existed)
 - CLI: uninstalled
 - Desktop app: removed (if applicable)
 - Reminder: if the user wants to reinstall later, activate `setup-openclaw`
 
+If a config snapshot was taken, remind the user it may contain credentials and
+should be stored securely or deleted.
+
 ## Escalation
-- If gateway service won't stop: `kill $(pgrep -f openclaw)` as a last resort
-- If files can't be deleted: check permissions, may need `sudo`
-- If CLI uninstall fails: `rm -f $(which openclaw)` to remove the binary directly
+- If gateway service won't stop:
+  - **Windows**: `Get-Process -Name '*openclaw*' | Stop-Process` — show the matched processes to the user first.
+  - **macOS / Linux**: `pgrep -af openclaw` to review matches, then `kill <PID>` for the specific PIDs. Avoid `kill $(pgrep -f openclaw)` blind — the pattern can match your own shell or an unrelated process.
+- If files can't be deleted:
+  - **Windows**: a running process usually holds the lock. Find it with `Get-Process` / Resource Monitor, close it, then retry. Do not take ownership of system paths to force a delete.
+  - **macOS / Linux**: check permissions; `sudo` may be needed. Prefer fixing ownership on the user's own directory over running the whole uninstall as root.
+- If CLI uninstall fails: remove the resolved binary or shim directly — `Get-Command openclaw | Select-Object Source` on Windows, `rm -f "$(which openclaw)"` on macOS/Linux — after confirming the path is inside a package-manager prefix and not a system directory.
 
 ## Tools referenced
 - `shell_run` — stop services, delete files, uninstall packages

--- a/skills/computer-repair-skill/references/playbook-setup-wifi-profile.md
+++ b/skills/computer-repair-skill/references/playbook-setup-wifi-profile.md
@@ -27,7 +27,7 @@ For WPA2 Personal: collect the Wi-Fi password using `secure_input` (secret_name:
 For WPA2 Enterprise: collect username via `text_input`, then password via `secure_input`.
 
 ## Step 4: Connect to the network
-Never interpolate the password into a transcript, shell command, process argument, or shell history. On macOS, prefer the system Wi-Fi UI or a host API that accepts the `secure_input` value without logging it; if an interactive prompt is required, let the user enter the password locally. On Windows, create the WLAN profile in a protected temporary location with `write_secret`, apply it with the native WLAN flow, and remove the temporary secret only after connectivity is verified.
+Never interpolate the password into a transcript, shell command, process argument, or shell history. On macOS, prefer the system Wi-Fi UI or a host API that accepts the `secure_input` value without logging it; if an interactive prompt is required, let the user enter the password locally. On Windows, create the WLAN profile in a protected temporary location with `write_secret`, apply it with the native WLAN flow (`netsh wlan add profile filename=<path> user=current`), and remove the temporary secret only after connectivity is verified. On Linux with NetworkManager, let `nmcli` read the secret from a file or agent rather than passing it as an argument — `nmcli --ask device wifi connect '<SSID>'` prompts locally, whereas `nmcli device wifi connect '<SSID>' password '<PSK>'` leaks the key into the process list and shell history.
 
 > Note: the password collected via secure_input can be written to a temp config file using `write_secret` if needed for scripted connection.
 

--- a/skills/computer-repair-skill/references/playbook-windows-update-troubleshooting.md
+++ b/skills/computer-repair-skill/references/playbook-windows-update-troubleshooting.md
@@ -2,7 +2,7 @@
 name: windows-update-troubleshooting
 description: Fix stuck Windows Updates, failed installations, and update service errors
 platform: windows
-last_reviewed: 2026-03-04
+last_reviewed: 2026-07-28
 author: upstream-maintainers
 source: bundled
 emoji: 🔄
@@ -14,9 +14,20 @@ emoji: 🔄
 User reports: Windows Update stuck, update won't install, update error code, system slow after update, "something went wrong" during update, pending restart that won't complete.
 
 ## Quick check
-Run `shell_run` with `powershell -Command "Get-WindowsUpdate -ErrorAction SilentlyContinue; Get-HotFix | Sort-Object InstalledOn -Descending | Select-Object -First 5"` to see recent updates.
+Run `shell_run` with `powershell -Command "Get-HotFix | Sort-Object InstalledOn -Descending | Select-Object -First 5 HotFixID, Description, InstalledOn"` to see recent updates.
+
+For a read-only view of what is still pending, run `shell_run` with:
+
+```powershell
+(New-Object -ComObject Microsoft.Update.Session).CreateUpdateSearcher().Search("IsInstalled=0 AND IsHidden=0").Updates |
+  Select-Object -First 10 Title, IsDownloaded, @{ n = 'SizeMB'; e = { [math]::Round($_.MaxDownloadSize / 1MB, 1) } }
+```
+
 - If recent updates installed fine → problem may be a specific failed update. Ask for the error code.
 - If no recent updates → update service may be stuck. Proceed with fix path.
+- Do **not** reach for `Get-WindowsUpdate` / `Install-WindowsUpdate`: those come from the third-party `PSWindowsUpdate` module, not from Windows. On a stock machine they fail, and this skill does not silently install third-party modules.
+
+Also check `win_system_info` for the OS build — some fixes only apply to Windows 11 24H2 and newer.
 
 Also check `win_disk_usage` — Windows Update needs 10-20 GB free.
 
@@ -29,10 +40,10 @@ Run `shell_run` with `powershell -Command "Test-Path 'HKLM:\SOFTWARE\Microsoft\W
 
 ### 2. Restart Windows Update services
 Run `win_restart_service` for `wuauserv` (Windows Update).
-Also restart these related services via `shell_run`:
-```
-net stop bits && net start bits
-net stop cryptSvc && net start cryptSvc
+Also restart these related services via `shell_run` in an **elevated** PowerShell:
+```powershell
+Restart-Service -Name bits -Force
+Restart-Service -Name cryptSvc -Force
 ```
 - `wuauserv` — the update engine
 - `bits` — Background Intelligent Transfer Service (downloads updates)
@@ -41,24 +52,29 @@ net stop cryptSvc && net start cryptSvc
 Restarting these three services fixes most transient update failures.
 
 ### 3. Clear the update cache
-If restarting services didn't help, clear the cached update files:
-Run `shell_run` with:
+If restarting services didn't help, clear the cached update files.
+Confirm with the user first — this is a state change, and the next update run has to re-download everything.
+Run `shell_run` in an **elevated** PowerShell with:
+```powershell
+Stop-Service -Name wuauserv, bits, cryptSvc -Force
+Rename-Item -LiteralPath 'C:\Windows\SoftwareDistribution' -NewName 'SoftwareDistribution.old'
+Rename-Item -LiteralPath 'C:\Windows\System32\catroot2' -NewName 'catroot2.old'
+Start-Service -Name cryptSvc, bits, wuauserv
 ```
-net stop wuauserv && net stop bits
-ren C:\Windows\SoftwareDistribution SoftwareDistribution.old
-ren C:\Windows\System32\catroot2 catroot2.old
-net start wuauserv && net start bits
-```
-This forces Windows to re-download updates from scratch. The old folders can be deleted after updates succeed.
+This forces Windows to re-download updates from scratch. Rename — do not delete: if the machine gets worse, stop the services again and rename the folders back.
+- If `Rename-Item` fails with "being used by another process", `TrustedInstaller` or `msiserver` still holds a handle. Reboot and retry before escalating; do not force-unlock the handle.
+- The `.old` folders can be removed after updates succeed, following the Inspect Before Delete steps in `safety-policy.md`.
 
-### 4. Run the Windows Update troubleshooter
-Run `shell_run` with `powershell -Command "Get-TroubleshootingPack -Path 'C:\Windows\diagnostics\system\WindowsUpdate' | Invoke-TroubleshootingPack -Unattended"`.
-Microsoft's built-in troubleshooter resets update components and fixes common issues automatically.
+### 4. Run the Windows Update troubleshooter (legacy platform — check availability first)
+The MSDT troubleshooters are deprecated: Microsoft began redirecting them to the Get Help platform in 2023 and planned removal of MSDT itself, so on current Windows 11 builds the pack is often gone.
+Probe before using it — run `shell_run` with `powershell -Command "Get-Command Get-TroubleshootingPack -ErrorAction SilentlyContinue; Test-Path 'C:\Windows\diagnostics\system\WindowsUpdate'"`.
+- Both present → `shell_run` with `powershell -Command "Get-TroubleshootingPack -Path 'C:\Windows\diagnostics\system\WindowsUpdate' | Invoke-TroubleshootingPack -Unattended"`.
+- Either missing → tell the user to open **Settings → System → Troubleshoot → Other troubleshooters → Windows Update** and run it there. There is no scriptable replacement; do not try to reinstall the legacy pack.
 
 ### 5. DISM and SFC repair
 If updates still fail, the system image may be corrupted:
 Run `shell_run` with:
-```
+```powershell
 DISM /Online /Cleanup-Image /RestoreHealth
 sfc /scannow
 ```
@@ -74,7 +90,8 @@ sfc /scannow
 - **Error code 0x800f081f** — source files not found. DISM can't download repair files. Try: `DISM /Online /Cleanup-Image /RestoreHealth /Source:C:\path\to\mounted\iso\sources\install.wim` with a mounted Windows ISO.
 - **"Updates are managed by your organization"** — Group Policy or MDM is controlling updates. Nothing to fix locally — contact IT admin.
 - **Metered connection blocking updates** — Windows won't download large updates on metered connections. Settings → Network & Internet → check if current connection is set to metered.
-- **Update loops (install → reboot → install again)** — a broken update is being retried. Hide the specific update: `powershell -Command "Hide-WindowsUpdate -KBArticleID 'KBXXXXXXX'"` or uninstall it from Settings → Update History → Uninstall updates.
+- **Update loops (install → reboot → install again)** — a broken update is being retried. Uninstall it from Settings → Windows Update → Update history → Uninstall updates, then pause updates for 1-2 weeks so the same build is not immediately re-offered. `Hide-WindowsUpdate` is a `PSWindowsUpdate` (third-party) cmdlet and is not available on a stock machine; do not install it without the user reviewing the module first.
+- **Elevation** — steps 2, 3 and 5 all require an elevated shell. Without it, `Stop-Service` and `Rename-Item` fail with access denied and the run looks like a Windows Update fault when it is not.
 
 ## Key signals
 - **"Stuck at a percentage for hours"** → if actively downloading/installing, wait up to 2 hours. If truly stuck, force-reboot and retry. Step 3 to clear cache.
@@ -84,7 +101,7 @@ sfc /scannow
 - **Specific KB error** → search the error code. Microsoft documents most update errors with specific fixes.
 
 ## Tools referenced
-- `shell_run` — run PowerShell and cmd commands for update management
+- `shell_run` — run elevated PowerShell commands for update management
 - `win_restart_service` — restart Windows Update and related services
 - `win_disk_usage` — check free space
 - `win_service_list` — check Windows Update service status
@@ -93,7 +110,7 @@ sfc /scannow
 
 ## Escalation
 If all steps fail:
-- Download the update manually from the Microsoft Update Catalog (https://catalog.update.microsoft.com) and install with `wusa.exe`.
+- Download the `.msu` manually from the Microsoft Update Catalog (https://catalog.update.microsoft.com) and install it with `wusa.exe '<PATH>.msu'`, or scriptably with `DISM /Online /Add-Package /PackagePath:'<PATH>.msu'`. Verify the KB number matches the OS build before installing.
 - For feature updates (e.g., 23H2 → 24H2): download the Update Assistant or Media Creation Tool from Microsoft.
 - For managed PCs: WSUS or SCCM may be blocking updates. Contact IT admin.
 - Persistent BSOD after updates: may need system restore or Windows repair install.

--- a/skills/computer-repair-skill/references/tool-contract.md
+++ b/skills/computer-repair-skill/references/tool-contract.md
@@ -8,7 +8,9 @@ Playbook 中的工具名是能力别名。宿主 Agent 无需提供同名工具�
 |---|---|
 | `shell_run` | 使用宿主终端工具运行当前平台命令。先确定 Shell，设置合理超时，保留退出码。状态变更前取得确认。 |
 | `ui_spa` | 在消息中展示诊断、计划、影响、回滚和下一动作。`RUN_STEP` 表示等待用户批准后由 Agent 执行；`WAIT_FOR_USER` 表示用户完成 GUI、手机或交互式步骤。 |
-| `ui_user_question` | 使用宿主提问能力。选项、普通文本和秘密输入三种模式保持互斥。 |
+| `ui_user_question` | 使用宿主提问能力。`options`、`text_input` 和 `secure_input` 三种模式保持互斥。 |
+| `options` | `ui_user_question` 的预设选项模式：给出有限、互斥的候选项，不接收自由文本。 |
+| `text_input` | `ui_user_question` 的普通文本模式：用于非秘密值（邮箱、SSID、App ID、主机名）。禁止用它收集密码或令牌。 |
 | `ui_done` | 仅在验证成功后给出完成摘要和前后数据。 |
 | `ui_info` | 给出事实性说明、剩余阻点或需要人工处理的部分。 |
 | `secure_input` | 使用宿主的遮罩输入或秘密管理功能。缺少此能力时，让用户在本机设置变量或文件，不接收秘密正文。 |

--- a/skills/computer-repair-skill/references/tools-windows.md
+++ b/skills/computer-repair-skill/references/tools-windows.md
@@ -36,7 +36,7 @@ HTTP 检查需要记录状态码、最终 URL 和耗时。目标不支持 `HEAD`
 |---|---|---|
 | `win_printer_list` | `Get-Printer` | 只读 |
 | `win_print_queue` | `Get-PrintJob -PrinterName '<PRINTER>'` | 只读 |
-| `win_cancel_print_jobs` | `Get-PrintJob -PrinterName '<PRINTER>' | Remove-PrintJob` | 高影响，先列出作业并确认 |
+| `win_cancel_print_jobs` | `Get-PrintJob -PrinterName '<PRINTER>' \| Remove-PrintJob` | 高影响，先列出作业并确认 |
 | `win_restart_spooler` | `Restart-Service -Name Spooler` | 会中断打印，先确认 |
 
 ```powershell


### PR DESCRIPTION
堆叠 PR 第 1/6 层 · base `main` · 2 commits · 20 files, +288 / −109

修确定性 bug：命令在目标平台上不成立、引用指向错误平台的变体、工具契约声明与正文不一致。不涉及新功能。

## 修了什么

### 跨平台断链与 macOS-only 命令（`642faf4`）

若干"跨平台"Playbook 实际只给了 macOS 命令，Windows/Linux 用户拿到的是必然失败的指令；引用其他 Playbook 时也一律指向 macOS 变体。现改为按平台分支，引用解析到平台匹配的变体：

- `playbook-health-baseline-check.md`：内存、uptime、系统更新、防火墙、备份五个小节补齐 Windows 与 Linux 分支。Windows 没有 `uptime` 命令，改用 `(Get-CimInstance Win32_OperatingSystem).LastBootUpTime`，并提示 fast startup 会让"关机"看起来不是重启。
- `playbook-local-data-audit.md`：新增平台路径映射表（家目录、Documents/Desktop/Downloads、per-user app data、SSH 密钥、OS 凭据库），Windows 侧先检查 Known Folder 是否重定向到 OneDrive，Linux 侧读 `~/.config/user-dirs.dirs` 而不是假设英文目录名。
- 磁盘清理、网络诊断、性能取证的交叉引用改为按平台指向 `windows-*` / `linux-*` / macOS 变体。

### Windows Update 流程与工具契约（`ea10ec1`）

`playbook-windows-update-troubleshooting.md` 有四处在真实机器上会失败或已失效：

| 问题 | 修正 |
|---|---|
| `Get-WindowsUpdate` / `Hide-WindowsUpdate` 来自第三方 `PSWindowsUpdate` 模块，stock 机器上不存在 | 移除，改用 `Microsoft.Update.Session` COM 的只读搜索；并明确说明本 Skill 不静默安装第三方模块 |
| `net stop x && net start x` —— Windows PowerShell 5.1 不支持 `&&` | 改 `Stop-Service` / `Start-Service`，并标注需要提权 |
| 无条件调用 MSDT 疑难解答，但 Microsoft 自 2023 年起重定向、后续移除了该平台 | 先探测 `Get-TroubleshootingPack` 与诊断包路径，缺失则回落到 Settings → System → Troubleshoot；说明没有可脚本化的替代 |
| `Get-HotFix \| Sort-Object InstalledOn` 但 `Select-Object` 没选中 `InstalledOn` | 补上排序列 |

另外把 `SoftwareDistribution` / `catroot2` 的处理从"删除"改为"重命名"，明确回滚路径，并要求变更前确认。

同时修正 14 个 Playbook 的 `## Tools referenced`。其中 7 个是**纯声明错误**——正文一字未动，只是声明的别名和正文实际用到的对不上：`browser-security-audit`、`credential-cleanup`、`dns-record-check`、`endpoint-security-check`、`mac-tune-up`、`performance-forensics`、`setup-backup`。另外 7 个是随上面的平台分支改动连带更新的。下一层的校验器会双向比对声明与使用，这里先把数据修对，否则 B 层一接上就是一片红。

## 验证

`python tests/validate_skill.py`（本层仍是 `main` 上的校验器）通过。

## 说明

本 PR 是六层堆叠的第一层，后续依次为 B 校验与测试、C CI 与 lint、D 脚本、E 内容扩展、F 文档与治理。合并本层后 GitHub 会自动把 B 的 base 重定向到 `main`。
