### PR TITLE
feat(scripts): 安装器生命周期改造与只读健康采集脚本（D/6）

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -100,6 +100,12 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Check cross-platform portability
+        # 四条静态规则：前三条各自对应一个只在非 Linux runner 上才会炸的真实故障
+        #（Bash 变量引用的花括号、5.1 步骤的纯 ASCII、write_text 的显式 LF），
+        # 第四条是同一类问题在 PowerShell 侧的镜像，目前零违规，纯防回归。
+        run: python tests/check_portability.py
+
       - name: Lint Python (ruff)
         run: |
           python -m pip install --disable-pip-version-check "ruff==${RUFF_VERSION}"
@@ -180,7 +186,8 @@ jobs:
           Write-Output "PSScriptAnalyzer: 无 Error/Warning。"
 
   # ---------------------------------------------------------------------------
-  # 安装器端到端行为。三平台真跑，不是只跑语法。
+  # 安装器端到端行为。三平台真跑，不是只跑语法：
+  # 首装 / 拒绝覆盖 / 校验 / 检出篡改 / --force 备份 / 幂等 / 卸载 / 链接模式全覆盖。
   # ---------------------------------------------------------------------------
   installer:
     name: installer (${{ matrix.os }})
@@ -200,42 +207,362 @@ jobs:
         shell: bash
         run: |
           destination="$RUNNER_TEMP/computer-repair-skills"
-          ./scripts/install.sh --target custom --destination "$destination"
-          test -f "$destination/computer-repair-skill/SKILL.md"
-          test -f "$destination/computer-repair-skill/NOTICE"
-          if ./scripts/install.sh --target custom --destination "$destination"; then
+          target="$destination/computer-repair-skill"
+          manifest="$destination/.computer-repair-skill-install.json"
+          backup_root="$destination/.computer-repair-skill-backups"
+          install=(./scripts/install.sh --target custom --destination "$destination")
+
+          echo "::group::预设清单"
+          ./scripts/install.sh --list-targets | grep -q "custom"
+          echo "::endgroup::"
+
+          echo "::group::--dry-run 必须零副作用"
+          "${install[@]}" --dry-run
+          if [ -e "$destination" ]; then
+            echo "::error::--dry-run 创建了 $destination" >&2
+            exit 1
+          fi
+          echo "::endgroup::"
+
+          echo "::group::首次安装"
+          "${install[@]}"
+          test -f "$target/SKILL.md"
+          test -f "$target/NOTICE"
+          test -f "$manifest"
+          python3 - "$manifest" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as handle:
+              data = json.load(handle)
+          assert data["schema"] == 1, data["schema"]
+          assert data["install_mode"] == "copy", data["install_mode"]
+          assert data["file_count"] == len(data["files"]) > 0, data["file_count"]
+          assert all(item["path"] and len(item["sha256"]) == 64 for item in data["files"])
+          print(f'清单合法：{data["file_count"]} 个文件，版本 {data["version"]}')
+          PY
+          echo "::endgroup::"
+
+          echo "::group::重复安装必须被拒绝"
+          if "${install[@]}"; then
             echo "::error::安装器不应静默覆盖现有 Skill" >&2
             exit 1
           fi
-          ./scripts/install.sh --target custom --destination "$destination" --force
-          find "$RUNNER_TEMP/external/computer-repair-skill/backups" -mindepth 1 -maxdepth 1 | grep -q .
+          echo "::endgroup::"
+
+          echo "::group::--verify 通过，篡改后必须失败"
+          "${install[@]}" --verify
+          printf '\n<!-- tampered -->\n' >> "$target/SKILL.md"
+          if "${install[@]}" --verify; then
+            echo "::error::--verify 没能检出被篡改的文件" >&2
+            exit 1
+          fi
+          echo "::endgroup::"
+
+          echo "::group::--force 修复并把备份放在目标目录内"
+          "${install[@]}" --force
+          "${install[@]}" --verify
+          test -d "$backup_root"
+          before="$(find "$backup_root" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+          test "$before" -eq 1
+          echo "::endgroup::"
+
+          echo "::group::同版本同内容的 --force 必须幂等，不再新增备份"
+          "${install[@]}" --force
+          after="$(find "$backup_root" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+          if [ "$after" != "$before" ]; then
+            echo "::error::幂等安装仍新增了备份（$before -> ${after}）" >&2
+            exit 1
+          fi
+          echo "::endgroup::"
+
+          echo "::group::清单外文件必须被 --verify 与 --uninstall 拦住"
+          printf 'stray\n' > "$target/stray-local-note.md"
+          if "${install[@]}" --verify; then
+            echo "::error::--verify 没能发现清单外文件" >&2
+            exit 1
+          fi
+          if "${install[@]}" --uninstall; then
+            echo "::error::--uninstall 不应在存在清单外文件时直接删除" >&2
+            exit 1
+          fi
+          echo "::endgroup::"
+
+          echo "::group::--uninstall --purge 不留残留"
+          "${install[@]}" --uninstall --purge --force
+          test ! -e "$target"
+          test ! -e "$manifest"
+          test ! -e "$backup_root"
+          echo "::endgroup::"
+
+          echo "::group::--link 模式"
+          "${install[@]}" --link
+          test -L "$target"
+          test -f "$target/SKILL.md"
+          "${install[@]}" --verify
+          "${install[@]}" --uninstall --purge
+          test ! -e "$target"
+          test -f skills/computer-repair-skill/SKILL.md
+          echo "::endgroup::"
 
       - name: Test PowerShell installer
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          $ErrorActionPreference = "Stop"
           $destination = Join-Path $env:RUNNER_TEMP "computer-repair-skills"
-          ./scripts/install.ps1 -Target custom -Destination $destination
-          if (-not (Test-Path (Join-Path $destination "computer-repair-skill/SKILL.md"))) {
-              throw "首次安装缺少 SKILL.md"
-          }
-          if (-not (Test-Path (Join-Path $destination "computer-repair-skill/NOTICE"))) {
-              throw "首次安装缺少 NOTICE"
+          $target = Join-Path $destination "computer-repair-skill"
+          $manifest = Join-Path $destination ".computer-repair-skill-install.json"
+          $backupRoot = Join-Path $destination ".computer-repair-skill-backups"
+
+          # 三点必须注意，否则测试会假通过：
+          #   1. install.ps1 用脚本作用域 trap 把预期内失败转成一行 "错误：…" 加 exit 1
+          #      （与 scripts/install.sh 的 fail() 对齐）。在同一个进程里用 & 调用时，
+          #      exit 不是异常，调用方的 catch 根本不会触发 —— 退出码才是唯一可靠信号。
+          #   2. $LASTEXITCODE 有粘性：脚本不显式 exit 时它保留上一次的值。这里每次调用
+          #      前清零，install.ps1 两条路径也都显式 exit，两头堵住误判。
+          #   3. 只能用哈希表 splat。数组 splat（@("-Force")）会把开关当成位置参数传，
+          #      开关根本不会生效 —— 这样 -DryRun 之类的断言就成了摆设。
+          function Invoke-Installer {
+              param([hashtable]$Option = @{})
+              $argument = @{ Target = "custom"; Destination = $destination }
+              foreach ($key in $Option.Keys) {
+                  $argument[$key] = $Option[$key]
+              }
+              $global:LASTEXITCODE = 0
+              & ./scripts/install.ps1 @argument
+              if ($LASTEXITCODE -ne 0) {
+                  $flag = ($argument.Keys | Sort-Object) -join ", "
+                  throw "install.ps1 以退出码 $LASTEXITCODE 结束（预期 0）：$flag"
+              }
           }
 
-          $refused = $false
-          try {
-              ./scripts/install.ps1 -Target custom -Destination $destination -ErrorAction Stop
-          }
-          catch {
-              $refused = $true
-          }
-          if (-not $refused) {
-              throw "安装器不应静默覆盖现有 Skill"
+          # Invoke-Installer 已经把非零退出码翻译成 throw，所以这里的 try/catch 同时覆盖
+          # 两种失败形态：trap 转出来的 exit 1，以及万一有路径绕过 trap 直接抛出的异常。
+          function Assert-InstallerFails {
+              param([hashtable]$Option = @{}, [string]$Because)
+              $rejected = $false
+              try {
+                  Invoke-Installer -Option $Option
+              }
+              catch {
+                  $rejected = $true
+                  Write-Output "已按预期拒绝：$($_.Exception.Message)"
+              }
+              if (-not $rejected) {
+                  throw $Because
+              }
           }
 
-          ./scripts/install.ps1 -Target custom -Destination $destination -Force
-          $backupRoot = Join-Path $env:RUNNER_TEMP "external/computer-repair-skill/backups"
-          if (-not (Get-ChildItem -LiteralPath $backupRoot -Directory)) {
-              throw "强制更新没有生成备份"
+          Write-Output "::group::预设清单"
+          # 安装器的状态输出走进程 stdout（[Console]::Out），不进 PowerShell 成功流，
+          # 所以必须开子进程才能捕获文本；在同一进程里用 = 赋值只会拿到空值。
+          $presetText = & pwsh -NoProfile -NonInteractive -File ./scripts/install.ps1 -ListTarget | Out-String
+          if ($LASTEXITCODE -ne 0) {
+              throw "-ListTarget 退出码不为 0：$LASTEXITCODE"
           }
+          if ($presetText -notmatch "custom") {
+              throw "-ListTarget 没有列出 custom 预设"
+          }
+          Write-Output "$presetText"
+          Write-Output "::endgroup::"
+
+          Write-Output "::group::-DryRun 必须零副作用"
+          Invoke-Installer -Option @{ DryRun = $true }
+          if (Test-Path -LiteralPath $destination) {
+              throw "-DryRun 创建了 $destination"
+          }
+          Write-Output "::endgroup::"
+
+          Write-Output "::group::首次安装"
+          Invoke-Installer
+          foreach ($relative in @("SKILL.md", "NOTICE")) {
+              if (-not (Test-Path -LiteralPath (Join-Path $target $relative))) {
+                  throw "首次安装缺少 $relative"
+              }
+          }
+          $data = Get-Content -LiteralPath $manifest -Raw -Encoding UTF8 | ConvertFrom-Json
+          if ($data.schema -ne 1) { throw "清单 schema 不是 1" }
+          if ($data.install_mode -ne "copy") { throw "清单 install_mode 不是 copy" }
+          if ($data.file_count -ne $data.files.Count) { throw "清单 file_count 与 files 数量不一致" }
+          if ($data.file_count -le 0) { throw "清单没有记录任何文件" }
+          foreach ($item in $data.files) {
+              if ($item.sha256.Length -ne 64) { throw "清单里有非法 sha256：$($item.path)" }
+          }
+          Write-Output "清单合法：$($data.file_count) 个文件，版本 $($data.version)"
+          Write-Output "::endgroup::"
+
+          Write-Output "::group::重复安装必须被拒绝"
+          Assert-InstallerFails -Because "安装器不应静默覆盖现有 Skill"
+          Write-Output "::endgroup::"
+
+          Write-Output "::group::-Verify 通过，篡改后必须失败"
+          Invoke-Installer -Option @{ Verify = $true }
+          Add-Content -LiteralPath (Join-Path $target "SKILL.md") -Value "<!-- tampered -->"
+          Assert-InstallerFails -Option @{ Verify = $true } -Because "-Verify 没能检出被篡改的文件"
+          Write-Output "::endgroup::"
+
+          Write-Output "::group::-Force 修复并把备份放在目标目录内"
+          Invoke-Installer -Option @{ Force = $true }
+          Invoke-Installer -Option @{ Verify = $true }
+          $before = @(Get-ChildItem -LiteralPath $backupRoot -Directory).Count
+          if ($before -ne 1) { throw "期望 1 个备份，实际 $before" }
+          Write-Output "::endgroup::"
+
+          Write-Output "::group::同版本同内容的 -Force 必须幂等，不再新增备份"
+          Invoke-Installer -Option @{ Force = $true }
+          $after = @(Get-ChildItem -LiteralPath $backupRoot -Directory).Count
+          if ($after -ne $before) { throw "幂等安装仍新增了备份（$before -> $after）" }
+          Write-Output "::endgroup::"
+
+          Write-Output "::group::清单外文件必须被 -Verify 与 -Uninstall 拦住"
+          Set-Content -LiteralPath (Join-Path $target "stray-local-note.md") -Value "stray"
+          Assert-InstallerFails -Option @{ Verify = $true } -Because "-Verify 没能发现清单外文件"
+          Assert-InstallerFails -Option @{ Uninstall = $true } -Because "-Uninstall 不应在存在清单外文件时直接删除"
+          Write-Output "::endgroup::"
+
+          Write-Output "::group::-Uninstall -Purge 不留残留"
+          Invoke-Installer -Option @{ Uninstall = $true; Purge = $true; Force = $true }
+          foreach ($path in @($target, $manifest, $backupRoot)) {
+              if (Test-Path -LiteralPath $path) { throw "卸载后仍残留 $path" }
+          }
+          Write-Output "::endgroup::"
+
+          Write-Output "::group::-Link 模式"
+          Invoke-Installer -Option @{ Link = $true }
+          $item = Get-Item -LiteralPath $target -Force
+          if (-not ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) {
+              throw "-Link 没有创建符号链接或联接"
+          }
+          if (-not (Test-Path -LiteralPath (Join-Path $target "SKILL.md"))) {
+              throw "链接指向的目录里没有 SKILL.md"
+          }
+          Invoke-Installer -Option @{ Verify = $true }
+          Invoke-Installer -Option @{ Uninstall = $true; Purge = $true }
+          if (Test-Path -LiteralPath $target) { throw "卸载后链接仍存在" }
+          if (-not (Test-Path -LiteralPath "skills/computer-repair-skill/SKILL.md")) {
+              throw "卸载链接时误删了源目录内容"
+          }
+          Write-Output "::endgroup::"
+
+      - name: Assert repository stays untouched
+        # 安装器只应该写目标目录：仓库工作区必须一字未变。
+        shell: bash
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git status --porcelain
+            echo "::error::安装器改动了仓库工作区" >&2
+            exit 1
+          fi
+
+  # ---------------------------------------------------------------------------
+  # 只读证据采集脚本。三平台真跑一遍，确认输出是合法结构化文档、退出码为 0，
+  # 且脚本除了 --output 指定的文件之外什么都没写。
+  # ---------------------------------------------------------------------------
+  collector:
+    name: collector (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Check out repository
+        # actions/checkout v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Run Bash collector
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          report="$RUNNER_TEMP/health.json"
+          ./scripts/collect-health.sh --list-sections
+          ./scripts/collect-health.sh --timeout 10 --output "$report"
+          python3 - "$report" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as handle:
+              data = json.load(handle)
+          assert data["schema"] == 1, data["schema"]
+          assert data["read_only"] is True
+          assert data["network_access"] is False
+          assert data["platform"] in {"linux", "macos"}, data["platform"]
+          assert len(data["sections"]) == 11, len(data["sections"])
+          probes = [probe for section in data["sections"] for probe in section["probes"]]
+          assert probes, "没有采集到任何探针"
+          skipped = sum(1 for probe in probes if probe["exit_code"] is None)
+          print(f'{len(data["sections"])} 个小节，{len(probes)} 项检查，{skipped} 项主动跳过')
+          PY
+          ./scripts/collect-health.sh --format markdown --sections overview,storage --no-identity > "$RUNNER_TEMP/health.md"
+          grep -q "^# 计算机健康证据采集（只读）" "$RUNNER_TEMP/health.md"
+          grep -q "^## 系统与启动概览（overview）" "$RUNNER_TEMP/health.md"
+          # --no-identity 只承诺报告头部不写主机名，所以这里只断言那一行不存在。
+          # 探针原始输出（uname -a）本来就含主机名，不能拿它当反例。
+          if grep -q "^- 主机：" "$RUNNER_TEMP/health.md"; then
+            echo "::error::--no-identity 仍然写出了主机标识行" >&2
+            exit 1
+          fi
+
+      - name: Run PowerShell collector (PowerShell 7)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $report = Join-Path $env:RUNNER_TEMP "health.json"
+          & ./scripts/collect-health.ps1 -ListSection
+          & ./scripts/collect-health.ps1 -TimeoutSecond 10 -OutputPath $report
+          $data = Get-Content -LiteralPath $report -Raw -Encoding UTF8 | ConvertFrom-Json
+          if ($data.schema -ne 1) { throw "schema 不是 1" }
+          if (-not $data.read_only) { throw "read_only 不是 true" }
+          if ($data.network_access) { throw "network_access 不是 false" }
+          if ($data.platform -ne "windows") { throw "platform 不是 windows：$($data.platform)" }
+          if ($data.sections.Count -ne 11) { throw "小节数不是 11：$($data.sections.Count)" }
+          $probes = @($data.sections | ForEach-Object { $_.probes })
+          if ($probes.Count -lt 1) { throw "没有采集到任何探针" }
+          $skipped = @($probes | Where-Object { $null -eq $_.exit_code }).Count
+          Write-Output "$($data.sections.Count) 个小节，$($probes.Count) 项检查，$skipped 项主动跳过"
+
+      - name: Run PowerShell collector (Windows PowerShell 5.1)
+        if: runner.os == 'Windows'
+        # 5.1 是 Windows 上的兜底运行时：必须证明脚本在它下面也能跑出合法文档。
+        # run 块只跑不断言，而且必须是纯 ASCII：Actions 把它写成不带 BOM 的临时 .ps1，
+        # 5.1 按系统 ANSI 代码页解码，中文字节里的 0x91-0x94 在 CP1252 下会变成排版
+        # 引号，提前闭合字符串并让整段脚本解析失败。中文断言见下一步的 pwsh。
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $report = Join-Path $env:RUNNER_TEMP "health-51.md"
+          & ./scripts/collect-health.ps1 -TimeoutSecond 10 -Format markdown -Section overview,security -NoIdentity -OutputPath $report
+          if (-not (Test-Path -LiteralPath $report)) {
+              throw "Windows PowerShell 5.1 produced no report at $report"
+          }
+          Write-Output "Windows PowerShell 5.1 wrote $((Get-Item $report).Length) bytes."
+
+      - name: Assert Windows PowerShell 5.1 output
+        if: runner.os == 'Windows'
+        # 上一步只证明"跑得完"；断言放在 pwsh 里做 —— PowerShell 7 的临时脚本按
+        # UTF-8 解码，可以安全地写中文针。读的是 5.1 刚写出的同一份报告。
+        shell: pwsh
+        run: |
+          $report = Join-Path $env:RUNNER_TEMP "health-51.md"
+          $text = Get-Content -LiteralPath $report -Raw -Encoding UTF8
+          if ($text -notmatch "计算机健康证据采集") {
+              throw "Markdown 标题缺失或编码错误（5.1 未按 UTF-8 解析脚本？）"
+          }
+          # -NoIdentity 只承诺报告头部不写主机名；探针原始输出仍可能含主机信息。
+          if ($text -match "(?m)^- 主机：") {
+              throw "-NoIdentity 仍然写出了主机标识行"
+          }
+          Write-Output "Windows PowerShell 5.1 输出 $($text.Length) 个字符。"
+
+      - name: Assert repository stays untouched
+        # 采集脚本声称"除 --output 外不写任何路径"，这一步就是那句话的证据。
+        shell: bash
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git status --porcelain
+            echo "::error::采集脚本改动了仓库工作区" >&2
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,70 @@
 
 ## [Unreleased]
 
+### Added
+
+- 安装器新增 `--verify` / `--uninstall`（含 `--purge`）/ `--list-targets` / `--link` /
+  `--dry-run` / `--backup-dir` / `--quiet`，PowerShell 版为对应的 `-Verify` / `-Uninstall` /
+  `-Purge` / `-ListTarget` / `-Link` / `-DryRun` / `-BackupDir` / `-Quiet`。
+- 安装清单 `<Skills 根目录>/.computer-repair-skill-install.json`（`schema: 1`）：
+  记录版本、来源目录、来源 commit、安装方式与每个文件的 sha256。两个安装器写出的
+  清单逐行同构，可以互相校验（PowerShell 装的副本能用 `install.sh --verify` 复核）。
+  `--verify` 靠它判断文件是否被改动，`--uninstall` 靠它确认目录归属，因此不会误删
+  用户自己放进去的文件（遇到清单外文件先列出并要求 `--force`）。
+- 安装器预设从 3 个扩到 21 个 Agent 目标，覆盖 Claude Code、Codex、Cursor、Gemini CLI、
+  GitHub Copilot、Windsurf、OpenCode、OpenClaw、Antigravity、Augment、Qwen Code、Trae、
+  Roo Code、Crush、Goose、Droid、Continue、OpenHands 等，另有 `custom` 走 `--destination`。
+- `scripts/collect-health.sh` 与 `scripts/collect-health.ps1`：只读健康证据采集脚本。
+  11 个小节，输出结构化 JSON 或 Markdown，支持 `--sections` / `--timeout` / `--output` /
+  `--no-identity`。严格只查不改、不联网、逐行过滤疑似凭据，除 `--output` 外不写任何路径。
+- CI 新增 `installer` 与 `collector` 两个三平台 job：安装器跑完整序列（dry-run 零副作用、
+  首装、清单校验、拒绝覆盖、篡改检出、`--force` 备份、幂等、清单外文件拦截、卸载无残留、
+  链接模式），采集脚本在三平台真实执行并断言输出合法；两个 job 最后都断言
+  `git status --porcelain` 为空，作为"只写目标目录"的证据。Windows 侧额外用
+  Windows PowerShell 5.1 再跑一遍采集脚本。
+- `tests/check_portability.py`：跨平台可移植性静态守卫，接入 CI 的 lint job。前三条规则
+  各自对应一个只在非 Linux runner 上才会炸的真实故障：Bash 脚本里紧跟非 ASCII 字符的
+  `$var` 必须写成 `${var}`；`shell: powershell` 步骤的 run 块必须是纯 ASCII；
+  `tests/` 里的 `write_text()` 必须显式传 `newline="\n"`。第四条规则防的是同一类问题在
+  PowerShell 侧的镜像：裸变量引用会吞掉紧随其后的 Unicode 字母（L\*）、数字（Nd）和组合
+  记号（Mn），`Set-StrictMode -Version Latest` 下直接抛「cannot be retrieved」。现有中文
+  消息因为全角标点恰好终止变量名而全部安全，这条规则把「恰好」变成「保证」。
+
+### Fixed
+
+- 备份目录从仓库相邻的 `external/computer-repair-skill/backups` 改为
+  `<Skills 根目录>/.computer-repair-skill-backups/<时间戳>/`。旧路径会在仓库外
+  凭空造出目录树，且与 `--destination` 无关，用户很难预料备份去了哪里。
+- `install.ps1` 现在拒绝多余的位置参数（`[CmdletBinding(PositionalBinding = $false)]`）。
+  此前 `install.ps1 -Target claude foo` 会静默忽略 `foo`，而 `install.sh` 是明确报错的。
+  `collect-health.ps1` 同样收紧。
+- `install.ps1` 遇到预期内的错误（尚未安装就 `-Verify`、`-Purge` 单独使用、
+  `-Verify` 与 `-Uninstall` 互斥等）不再向用户抛出完整 PowerShell 异常堆栈。
+  脚本作用域 `trap` 把消息收敛为单行 `错误：<原因>` 写入 stderr 并以 1 退出，
+  与 `install.sh` 的 `fail()` 输出逐字对齐；主入口分派之后显式 `exit 0`，避免脚本
+  内部调用过 `git` 之后 `$LASTEXITCODE` 残留而被调用方误判为失败。CI 的
+  `Assert-InstallerFails` 相应改为按退出码判定 —— 同进程 `& ./install.ps1` 调用时
+  子脚本的 `exit 1` 不是异常，`catch` 不会触发，只看异常会漏掉真实失败。
+- 重复安装不再无条件产生备份：已安装版本与仓库内容逐字节一致时，`--force` 直接报告
+  "无需变更"并退出。
+- macOS 自带的 Bash 3.2 会把紧跟在 `$var` 后面的中文首字节并进变量名（BSD libc 的
+  `isalnum()` 在 UTF-8 locale 下对 0x80-0xFF 返回真），于是 `set -u` 下
+  `fail "目标已存在：$target_path。"` 不会打印那句提示，而是以
+  `target_path\xef: unbound variable` 退出。`install.sh` 12 处、`collect-health.sh`
+  7 处全部改写为 `${var}`。glibc 不复现这个行为，所以只有 macOS runner 能抓到它。
+- `tests/playbook_registry.py --write` 和校验器回归测试在 Windows 上会写出 CRLF
+  —— `Path.write_text()` 默认做行尾翻译 —— 生成的 `README.md` / `playbook-index.md`
+  随即被 `.gitattributes` 的 LF 约束判失败。所有文本写入显式传 `newline="\n"`。
+- `.github/workflows/validate.yml` 里两个 `shell: powershell` 步骤的 run 块改为纯 ASCII，
+  中文断言挪到紧随其后的 `shell: pwsh` 步骤。Actions 把 5.1 步骤的正文写成不带 BOM 的
+  临时 `.ps1`，5.1 按系统 ANSI 代码页解码，CP1252 把「错」的 0x94 字节读成右双引号，
+  字符串提前闭合，整段脚本解析失败。
+
+### Changed
+
+- README 安装章节重写：补齐全部新选项、更正备份路径、说明安装清单，并诚实标注
+  `scripts/` 是可选辅助工具 —— Skill 的核心仍然是 Markdown Playbook。
+
 ## [1.1.0] - 2026-07-28
 
 首个带版本号的发布。主题是**跨平台正确性**与**可验证性**：把"看起来通过"的校验
@@ -35,7 +99,8 @@
 - `tests/validate_skill.py` 重写。行为差异：
   - 删除全部硬编码簿记（Playbook 总数、上游/本地数量、21 项本地文件字面量集合），
     改为从 frontmatter 派生并与登记生成器交叉核对。
-  - 新增 error / warning 分级与 `--strict` 开关（CI 用 `--strict`）。
+  - 新增 error / warning 分级与 `--strict` 开关。CI 目前**不加** `--strict`：
+    仓库里还有 10 个"已登记但无人使用"的工具别名，等对应 Playbook 补齐后再收紧。
   - 工具契约改为**双向**校验：声明的别名必须已在映射表登记，正文用到的登记别名
     必须声明，且每个 Playbook 至少声明一个已登记别名。
   - 工具别名宇宙改为只从映射表**表格首列**解析，不再把正文里的原始命令

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ macOS / Linux：
 ./scripts/install.sh --target agents
 ```
 
-其中 `codex`、`claude`、`agents` 会使用对应的默认 Skills 根目录。需要自定义位置时：
+其中 `codex`、`claude`、`agents` 会使用对应的默认 Skills 根目录。完整预设列表用 `-ListTarget` / `--list-targets` 查看。需要自定义位置时：
 
 ```powershell
 .\scripts\install.ps1 -Target custom -Destination "D:\path\to\skills"
@@ -113,7 +113,26 @@ macOS / Linux：
 ./scripts/install.sh --target custom --destination "/path/to/skills"
 ```
 
-目标目录已存在时，安装器默认拒绝覆盖；确认升级时显式加 `-Force` 或 `--force`，旧版本会先备份到相邻的 `external/computer-repair-skill/backups`。
+安装器的行为约定：
+
+| 需求 | PowerShell | Bash |
+| --- | --- | --- |
+| 看会做什么，但不落盘 | `-DryRun` | `--dry-run` |
+| 列出全部预设及其目标目录 | `-ListTarget` | `--list-targets` |
+| 覆盖已存在的安装（先自动备份） | `-Force` | `--force` |
+| 复核已安装副本是否被改动 | `-Verify` | `--verify` |
+| 卸载（默认保留备份） | `-Uninstall` | `--uninstall` |
+| 卸载并一并删除备份 | `-Uninstall -Purge` | `--uninstall --purge` |
+| 用链接指向仓库，便于本地改 Playbook | `-Link` | `--link` |
+| 只输出错误 | `-Quiet` | `--quiet` |
+
+几点值得先知道：
+
+- **默认绝不覆盖。** 目标目录已存在时安装器直接报错退出，不做任何写入；确认升级请显式加 `-Force` / `--force`。
+- **备份放在 Skills 根目录内。** 路径是 `<Skills 根目录>/.computer-repair-skill-backups/<时间戳>/`，不会写到仓库或其他位置；`--backup-dir` 可以改到别处。
+- **安装后有清单。** `<Skills 根目录>/.computer-repair-skill-install.json` 记录版本、来源 commit 和每个文件的 sha256。`--verify` 用它判断文件是否被改动，`--uninstall` 用它确认目录归属 —— 所以卸载不会误删你自己放进去的文件（遇到清单外文件会先列出来并要求 `--force`）。
+- **重复安装是幂等的。** 已安装版本与仓库内容逐字节一致时，`--force` 会直接说"无需变更"并退出，不会多产生一份备份。
+- **两个安装器写出的清单逐行同构**，可以互相校验：用 PowerShell 装的副本，能用 `install.sh --verify` 复核，反之亦然。
 
 </details>
 
@@ -306,9 +325,48 @@ assets/
 └── computer-repair-cover.svg  # README 封面图
 scripts/
 ├── install.ps1              # Windows 安装器
-└── install.sh               # macOS/Linux 安装器
+├── install.sh               # macOS/Linux 安装器
+├── collect-health.ps1       # Windows 只读证据采集（可选）
+└── collect-health.sh        # macOS/Linux 只读证据采集（可选）
 tests/validate_skill.py      # 无第三方依赖的仓库验证器
 ```
+
+`scripts/` 是**可选的辅助工具**，不是这个 Skill 的核心。核心始终是 `SKILL.md` 与 `references/` 下的
+Markdown Playbook：Agent 靠它们判断做什么、先确认什么、怎么验证。脚本只解决两件周边事情 ——
+把 Skill 放到正确的目录，以及在动手之前把机器现状抓成一份可复核的证据。两个脚本都是纯文本、
+可逐行审阅的，没有任何编译产物或下载步骤。
+
+## 🩺 只读证据采集（可选）
+
+排障的第一步通常是"先看清楚现在是什么状态"。`scripts/collect-health.*` 把这一步固化成一条命令，
+输出结构化 JSON（喂给 Agent）或 Markdown（贴进工单）：
+
+```powershell
+.\scripts\collect-health.ps1 -Format markdown -OutputPath health.md
+.\scripts\collect-health.ps1 -ListSection
+.\scripts\collect-health.ps1 -Section storage,logs,power
+```
+
+```bash
+./scripts/collect-health.sh --format markdown --output health.md
+./scripts/collect-health.sh --list-sections
+./scripts/collect-health.sh --sections storage,logs,power
+```
+
+共 11 个小节：`overview`、`hardware`、`storage`、`memory`、`process`、`network`、`services`、
+`updates`、`security`、`logs`、`power`。
+
+采集脚本的边界写在脚本头部，并由 CI 逐条验证：
+
+- **只查不改。** 全部命令都是查询类，不安装、不卸载、不删除、不改注册表、不重启服务、不动电源或安全策略。
+- **不联网。** 需要联网才能回答的检查（例如"待安装更新清单"）会被显式标记为 `skipped`，并指向对应 Playbook，而不是偷偷发请求。
+- **不回显秘密。** 输出前逐行过滤，凡命中 `password` / `token` / `secret` / `api_key` / `psk` 等关键字的行整行替换为占位符。
+- **除 `--output` 指定的文件外不写任何路径。** CI 在三个平台跑完采集后都会断言仓库工作区一字未变。
+- `--no-identity` 只保证报告头部不记录主机名与用户名；探针的原始输出（例如 `uname -a`）仍可能包含主机信息，交付前请人工复核。
+
+两个版本刻意保留一处差异：`exit_code` 在 Bash 版是 `sh -c` 的退出码，在 PowerShell 版是"0 = 无错误、
+非 0 = 原生命令退出码或存在 PowerShell 错误记录记 1"；两者都用 `124` 表示超时（沿用 GNU `timeout` 的约定），
+`null` 表示该检查被主动跳过。
 
 ## 🧪 开发与验证
 
@@ -350,7 +408,11 @@ pwsh -c 'Invoke-ScriptAnalyzer -Path ./scripts -Recurse -Severity Error,Warning'
 
 验证器会检查 Skill frontmatter、Agent 元数据、Playbook 描述唯一性与分类登记、工具别名双向契约、跨平台路由（禁止把 Windows/Linux 用户导向 macOS-only 流程）、远程脚本管道执行等安全红线、路由索引与 README 派生计数、本地 Markdown 链接与图片、许可证一致性、格式卫生（行尾、代码块语言标注、表格转义）、占位符和疑似凭据。
 
-GitHub Actions 会在 **Ubuntu、Windows 和 macOS** 三个平台重复执行验证器、生成器一致性检查和回归测试，另外单独运行 Python/Shell/Markdown/workflow 静态检查、PowerShell 分析，并真实测试安装器的首次安装、拒绝覆盖、备份和强制更新路径。
+GitHub Actions 会在 **Ubuntu、Windows 和 macOS** 三个平台重复执行验证器、生成器一致性检查和回归测试，另外单独运行 Python/Shell/Markdown/workflow 静态检查和 PowerShell 分析。安装器与采集脚本不是只跑语法检查，而是在三个平台真实执行一遍完整序列：
+
+- 安装器：`--dry-run` 零副作用 → 首次安装 → 清单字段与 sha256 校验 → 重复安装必须被拒绝 → `--verify` 通过 → 篡改文件后 `--verify` 必须失败 → `--force` 修复并只产生一份备份 → 同内容再 `--force` 必须幂等 → 放入清单外文件后 `--verify` 与 `--uninstall` 必须都被拦住 → `--uninstall --purge --force` 不留残留 → `--link` 模式安装、校验、卸载且不误删源目录。
+- 采集脚本：三平台执行一遍，断言输出是合法结构化文档、11 个小节齐全、`read_only` 与 `network_access` 标记正确；Windows 侧额外用 Windows PowerShell 5.1 再跑一遍，确认在旧运行时下也能输出正确编码的报告。
+- 两个 job 的最后一步都断言 `git status --porcelain` 为空 —— 这是"脚本只写目标目录"这句话的证据，而不是承诺。
 
 新增或修改 Playbook 前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。安全问题请按 [SECURITY.md](SECURITY.md) 私下报告。
 

--- a/scripts/collect-health.ps1
+++ b/scripts/collect-health.ps1
@@ -1,0 +1,618 @@
+﻿# PositionalBinding = $false：所有参数一律具名。
+# 否则 `-ListSection json` 这类手滑会把多余的位置参数静默吞掉，
+# 而 scripts/collect-health.sh 是明确报错的，两个脚本的行为必须一致。
+[CmdletBinding(PositionalBinding = $false)]
+param(
+    [ValidateSet("json", "markdown")]
+    [string]$Format = "json",
+
+    [string]$OutputPath,
+
+    [string[]]$Section,
+
+    [switch]$ListSection,
+
+    [ValidateRange(1, 600)]
+    [int]$TimeoutSecond = 20,
+
+    [switch]$NoIdentity,
+
+    [switch]$Quiet
+)
+
+# 只读采集一台 Windows 机器的健康证据，输出结构化 JSON 或 Markdown。
+#
+# 安全边界（与 skills/computer-repair-skill/references/safety-policy.md 一致）：
+#   * 只执行查询类命令：不安装、不卸载、不删除、不改注册表、不重启服务、不修改电源或安全策略。
+#   * 不发起任何网络请求；需要联网才能回答的检查（例如待安装更新清单）会被显式标记为 skipped。
+#   * 输出前逐行过滤，凡含 password / token / secret 等关键字的行整行替换为占位符。
+#   * 除 -OutputPath 指定的文件外不写入任何路径。
+#
+# -NoIdentity 只保证报告头部不记录主机名与用户名；探针的原始输出（例如 w32tm /query /status）
+# 仍可能包含主机信息，需要完全脱敏请在交付前人工复核。
+#
+# 与 scripts/collect-health.sh 的差异（刻意保留，已在 README 说明）：
+#   * exit_code 语义：0 = 无错误；非 0 = 原生命令的退出码，或有 PowerShell 错误记录时记 1；
+#     124 = 超过 -TimeoutSecond 未返回（沿用 GNU timeout 的约定）。
+#   * 探针在同进程的独立 runspace 里执行，因此超时可以被真正打断，而不需要为每项检查开新进程。
+#
+# 这个脚本是可选的辅助工具。Skill 的核心仍然是 Markdown Playbook：
+# 采集到的证据只是给 Agent 和维修工程师看的输入，任何变更动作仍由 Playbook 驱动。
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$CollectorName = "collect-health.ps1"
+$OutputSchema = 1
+
+$script:QuietOutput = $Quiet.IsPresent
+$script:OutputFormat = $Format
+$script:ProbeTimeout = $TimeoutSecond
+$script:Buffer = New-Object System.Text.StringBuilder
+$script:ProbeRunspace = $null
+$script:ProbeIndex = 0
+$script:ProbeCount = 0
+$script:ProbeFailureCount = 0
+$script:SkipCount = 0
+
+# 小节顺序即输出顺序，与 scripts/collect-health.sh 的 section_catalog 一一对应。
+$SectionCatalog = @(
+    @{ Id = "overview"; Title = "系统与启动概览" }
+    @{ Id = "hardware"; Title = "硬件与固件" }
+    @{ Id = "storage"; Title = "存储与文件系统" }
+    @{ Id = "memory"; Title = "内存与交换" }
+    @{ Id = "process"; Title = "进程占用排行" }
+    @{ Id = "network"; Title = "网络配置与监听" }
+    @{ Id = "services"; Title = "服务与计划任务" }
+    @{ Id = "updates"; Title = "系统更新状态（只读本地缓存）" }
+    @{ Id = "security"; Title = "安全基线开关" }
+    @{ Id = "logs"; Title = "近期错误日志与崩溃报告" }
+    @{ Id = "power"; Title = "电源、电池与温度" }
+)
+
+$CredentialPattern = "password|passwd|secret|token|api[_-]?key|apikey|access[_-]?key|bearer|credential|private key|psk"
+
+# Markdown 代码围栏。用 [char] 拼出来，避免在双引号字符串里数反引号转义。
+$CodeFence = [string][char]0x60 + [string][char]0x60 + [string][char]0x60
+
+function Write-Status {
+    <# 进度与提示统一走标准错误：标准输出要保持是一份干净的 JSON 或 Markdown。 #>
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Message)
+
+    if (-not $script:QuietOutput) {
+        [Console]::Error.WriteLine($Message)
+    }
+}
+
+function Show-SectionList {
+    <# 列出可用小节；供 -ListSection 使用。 #>
+    param([Parameter(Mandatory = $true)][object[]]$Catalog)
+
+    [Console]::Out.WriteLine("可用小节（-Section 接受逗号分隔或数组形式的多个 id）：")
+    foreach ($entry in $Catalog) {
+        [Console]::Out.WriteLine(("  {0,-10} {1}" -f $entry.Id, $entry.Title))
+    }
+}
+
+function Get-SectionTitle {
+    param(
+        [Parameter(Mandatory = $true)][object[]]$Catalog,
+        [Parameter(Mandatory = $true)][string]$Id
+    )
+
+    foreach ($entry in $Catalog) {
+        if ($entry.Id -eq $Id) {
+            return $entry.Title
+        }
+    }
+    return $Id
+}
+
+function Get-HostPlatform {
+    <# 只用 .NET 判定平台：$IsWindows 在 Windows PowerShell 5.1 里并不存在。 #>
+    param()
+
+    if ([Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT) {
+        return "windows"
+    }
+    if ([Environment]::OSVersion.Platform -eq [PlatformID]::Unix) {
+        return "unix"
+    }
+    return "unknown"
+}
+
+function Protect-SensitiveText {
+    <# 整行丢弃可能含凭据的输出。宁可少给一行证据，也不要把秘密写进报告。 #>
+    param([AllowEmptyString()][string]$Text)
+
+    if ([string]::IsNullOrEmpty($Text)) {
+        return ""
+    }
+
+    $normalized = $Text.Replace("`r`n", "`n").Replace("`r", "`n")
+    $kept = New-Object System.Collections.Generic.List[string]
+    foreach ($line in $normalized.Split("`n")) {
+        if ($line -imatch $CredentialPattern) {
+            $kept.Add("[已按只读采集策略移除可能含凭据的一行]")
+        }
+        else {
+            $kept.Add($line)
+        }
+    }
+    return ($kept -join "`n").TrimEnd("`n")
+}
+
+function Convert-ToJsonText {
+    <# 手写 JSON 字符串转义，保持与 Bash 版逐字节一致：
+       控制字符里只保留制表与换行，其余直接丢弃（对应 Bash 版的 tr -d）。 #>
+    param([AllowEmptyString()][string]$Value)
+
+    if ([string]::IsNullOrEmpty($Value)) {
+        return ""
+    }
+
+    $builder = New-Object System.Text.StringBuilder
+    foreach ($character in $Value.ToCharArray()) {
+        $code = [int]$character
+        if ($character -eq '\') {
+            [void]$builder.Append('\\')
+        }
+        elseif ($character -eq '"') {
+            [void]$builder.Append('\"')
+        }
+        elseif ($character -eq "`n") {
+            [void]$builder.Append('\n')
+        }
+        elseif ($character -eq "`t") {
+            [void]$builder.Append('\t')
+        }
+        elseif ($code -lt 32) {
+            continue
+        }
+        else {
+            [void]$builder.Append($character)
+        }
+    }
+    return $builder.ToString()
+}
+
+function Write-Buffer {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Text)
+
+    [void]$script:Buffer.Append($Text)
+}
+
+function Open-ProbeRunspace {
+    <# 探针跑在独立 runspace 里：一是可以用 WaitOne 实现真正的超时打断，
+       二是探针拿不到本脚本的变量，避免误引用。 #>
+    param()
+
+    $runspace = [RunspaceFactory]::CreateRunspace()
+    $runspace.Open()
+    return $runspace
+}
+
+function Invoke-ProbeCommand {
+    <# 执行一条只读命令，返回 @{ Output = 文本; ExitCode = 整数 }。 #>
+    param([Parameter(Mandatory = $true)][string]$Command)
+
+    if ($null -eq $script:ProbeRunspace) {
+        $script:ProbeRunspace = Open-ProbeRunspace
+    }
+
+    $shell = [PowerShell]::Create()
+    $shell.Runspace = $script:ProbeRunspace
+
+    # 探针里的错误不应该中断采集，所以显式把 ErrorActionPreference 降为 Continue；
+    # 每次都把 LASTEXITCODE 归零，避免上一条原生命令的退出码串到下一项。
+    $prelude = "`$ErrorActionPreference = 'Continue'" + "`n" + "`$global:LASTEXITCODE = 0" + "`n"
+    $wrapped = $prelude + "& {" + "`n" + $Command + "`n" + "} | Out-String -Width 200"
+    [void]$shell.AddScript($wrapped)
+
+    $output = ""
+    $exitCode = 0
+    $handle = $shell.BeginInvoke()
+
+    if (-not $handle.AsyncWaitHandle.WaitOne($script:ProbeTimeout * 1000)) {
+        [void]$shell.Stop()
+        $shell.Dispose()
+        # 被打断的 runspace 状态不可信，直接换一个新的给后续探针用。
+        $script:ProbeRunspace.Dispose()
+        $script:ProbeRunspace = $null
+        return @{ Output = "命令超过 $($script:ProbeTimeout) 秒未返回，已停止采集这一项。"; ExitCode = 124 }
+    }
+
+    try {
+        $results = $shell.EndInvoke($handle)
+        if ($null -ne $results) {
+            $output = ($results -join "")
+        }
+
+        $errorText = ""
+        if ($shell.Streams.Error.Count -gt 0) {
+            $rendered = New-Object System.Collections.Generic.List[string]
+            foreach ($record in $shell.Streams.Error) {
+                $rendered.Add($record.ToString())
+            }
+            $errorText = ($rendered -join "`n")
+        }
+
+        $nativeExit = $script:ProbeRunspace.SessionStateProxy.GetVariable("LASTEXITCODE")
+        if (($nativeExit -is [int]) -and ($nativeExit -ne 0)) {
+            $exitCode = $nativeExit
+        }
+        elseif ($errorText.Length -gt 0) {
+            $exitCode = 1
+        }
+
+        if ($errorText.Length -gt 0) {
+            if ($output.Length -gt 0) {
+                $output = $output.TrimEnd("`r", "`n") + "`n" + $errorText
+            }
+            else {
+                $output = $errorText
+            }
+        }
+    }
+    catch {
+        $output = $_.Exception.Message
+        $exitCode = 1
+    }
+    finally {
+        $shell.Dispose()
+    }
+
+    return @{ Output = $output; ExitCode = $exitCode }
+}
+
+function Write-ProbeRecord {
+    <# 把一条探针结果写进缓冲区。JSON 布局与 Bash 版保持逐行同构。 #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Label,
+        [AllowEmptyString()][string]$Command = "",
+        [AllowEmptyString()][string]$Output = "",
+        [AllowNull()][object]$ExitCode = $null
+    )
+
+    $script:ProbeCount = $script:ProbeCount + 1
+    if (($null -ne $ExitCode) -and ($ExitCode -ne 0)) {
+        $script:ProbeFailureCount = $script:ProbeFailureCount + 1
+    }
+
+    $clean = Protect-SensitiveText $Output
+
+    if ($script:OutputFormat -eq "json") {
+        if ($script:ProbeIndex -gt 0) {
+            Write-Buffer ",`n"
+        }
+        Write-Buffer "      {`n"
+        Write-Buffer "        `"label`": `"$(Convert-ToJsonText $Label)`",`n"
+        if ([string]::IsNullOrEmpty($Command)) {
+            Write-Buffer "        `"command`": null,`n"
+        }
+        else {
+            Write-Buffer "        `"command`": `"$(Convert-ToJsonText $Command)`",`n"
+        }
+        if ($null -eq $ExitCode) {
+            Write-Buffer "        `"exit_code`": null,`n"
+        }
+        else {
+            Write-Buffer "        `"exit_code`": $ExitCode,`n"
+        }
+        Write-Buffer "        `"output`": `"$(Convert-ToJsonText $clean)`"`n"
+        Write-Buffer "      }"
+    }
+    else {
+        Write-Buffer "### $Label`n`n"
+        if (-not [string]::IsNullOrEmpty($Command)) {
+            Write-Buffer ($CodeFence + "text`n")
+            Write-Buffer "PS> $Command`n"
+            Write-Buffer "$clean`n"
+            Write-Buffer ($CodeFence + "`n`n")
+            Write-Buffer "退出码：$ExitCode`n`n"
+        }
+        else {
+            Write-Buffer "$clean`n`n"
+        }
+    }
+
+    $script:ProbeIndex = $script:ProbeIndex + 1
+}
+
+function Write-SkipRecord {
+    <# 记录一条被主动跳过的检查，并说明为什么不做。 #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$Reason
+    )
+
+    $script:SkipCount = $script:SkipCount + 1
+    Write-ProbeRecord -Label $Label -Command "" -Output "已跳过：$Reason" -ExitCode $null
+}
+
+function Invoke-Probe {
+    param(
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$Command
+    )
+
+    $result = Invoke-ProbeCommand -Command $Command
+    Write-ProbeRecord -Label $Label -Command $Command -Output $result.Output -ExitCode $result.ExitCode
+}
+
+function Invoke-ProbeIfCommand {
+    <# 命令不存在时记为 skipped，而不是把 "找不到 cmdlet" 当成机器故障。 #>
+    param(
+        [Parameter(Mandatory = $true)][string]$CommandName,
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$Command
+    )
+
+    if (Get-Command -Name $CommandName -ErrorAction SilentlyContinue) {
+        Invoke-Probe -Label $Label -Command $Command
+    }
+    else {
+        Write-SkipRecord -Label $Label -Reason "本机没有 $CommandName，无法采集这一项。"
+    }
+}
+
+function Invoke-SectionProbe {
+    <# 每个小节的只读探针清单。命令文本原样写进输出，方便工程师复核。 #>
+    param([Parameter(Mandatory = $true)][string]$Id)
+
+    switch ($Id) {
+        "overview" {
+            Invoke-ProbeIfCommand -CommandName "Get-CimInstance" -Label "操作系统版本与启动时间" `
+                -Command "Get-CimInstance -ClassName Win32_OperatingSystem | Select-Object Caption, Version, BuildNumber, OSArchitecture, InstallDate, LastBootUpTime | Format-List"
+            Invoke-ProbeIfCommand -CommandName "Get-CimInstance" -Label "已连续运行时长" `
+                -Command '$os = Get-CimInstance -ClassName Win32_OperatingSystem; ((Get-Date) - $os.LastBootUpTime).ToString("d\.hh\:mm\:ss")'
+            Invoke-Probe -Label "PowerShell 版本" `
+                -Command '$PSVersionTable.PSVersion.ToString(); "Edition: " + $PSVersionTable.PSEdition'
+            Invoke-ProbeIfCommand -CommandName "Get-ExecutionPolicy" -Label "执行策略" `
+                -Command "Get-ExecutionPolicy -List | Format-Table -AutoSize"
+            Invoke-Probe -Label "当前时间（本地与 UTC）" `
+                -Command '(Get-Date).ToString("yyyy-MM-dd HH:mm:ss zzz"); (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")'
+            Invoke-ProbeIfCommand -CommandName "w32tm" -Label "时间同步状态" `
+                -Command "w32tm /query /status"
+        }
+        "hardware" {
+            Invoke-ProbeIfCommand -CommandName "Get-CimInstance" -Label "机型与制造商" `
+                -Command "Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object Manufacturer, Model, SystemFamily, NumberOfProcessors, TotalPhysicalMemory | Format-List"
+            Invoke-ProbeIfCommand -CommandName "Get-CimInstance" -Label "CPU 概览" `
+                -Command "Get-CimInstance -ClassName Win32_Processor | Select-Object Name, NumberOfCores, NumberOfLogicalProcessors, MaxClockSpeed | Format-List"
+            Invoke-ProbeIfCommand -CommandName "Get-CimInstance" -Label "固件（BIOS/UEFI）版本" `
+                -Command "Get-CimInstance -ClassName Win32_BIOS | Select-Object Manufacturer, SMBIOSBIOSVersion, ReleaseDate | Format-List"
+            Invoke-ProbeIfCommand -CommandName "Get-CimInstance" -Label "内存条清单" `
+                -Command "Get-CimInstance -ClassName Win32_PhysicalMemory | Select-Object BankLabel, DeviceLocator, Capacity, Speed, Manufacturer | Format-Table -AutoSize"
+            Invoke-ProbeIfCommand -CommandName "Get-PnpDevice" -Label "状态异常的设备（设备管理器黄色感叹号）" `
+                -Command 'Get-PnpDevice | Where-Object { $_.Status -ne "OK" } | Select-Object Status, Class, FriendlyName, InstanceId | Format-Table -AutoSize'
+        }
+        "storage" {
+            Invoke-ProbeIfCommand -CommandName "Get-Volume" -Label "卷与剩余空间" `
+                -Command 'Get-Volume | Sort-Object DriveLetter | Select-Object DriveLetter, FileSystemLabel, FileSystem, HealthStatus, @{ Name = "SizeGB"; Expression = { [math]::Round($_.Size / 1GB, 1) } }, @{ Name = "FreeGB"; Expression = { [math]::Round($_.SizeRemaining / 1GB, 1) } } | Format-Table -AutoSize'
+            Invoke-ProbeIfCommand -CommandName "Get-Disk" -Label "磁盘与分区风格" `
+                -Command "Get-Disk | Select-Object Number, FriendlyName, BusType, PartitionStyle, HealthStatus, OperationalStatus | Format-Table -AutoSize"
+            Invoke-ProbeIfCommand -CommandName "Get-PhysicalDisk" -Label "物理磁盘健康状态" `
+                -Command 'Get-PhysicalDisk | Select-Object DeviceId, FriendlyName, MediaType, HealthStatus, OperationalStatus, @{ Name = "SizeGB"; Expression = { [math]::Round($_.Size / 1GB, 1) } } | Format-Table -AutoSize'
+            Invoke-ProbeIfCommand -CommandName "Get-StorageReliabilityCounter" -Label "SMART 可靠性计数（可能需要管理员）" `
+                -Command 'Get-PhysicalDisk | ForEach-Object { $_ | Get-StorageReliabilityCounter } | Select-Object DeviceId, Temperature, Wear, PowerOnHours, ReadErrorsTotal, WriteErrorsTotal | Format-Table -AutoSize'
+        }
+        "memory" {
+            Invoke-ProbeIfCommand -CommandName "Get-CimInstance" -Label "物理内存用量" `
+                -Command '$os = Get-CimInstance -ClassName Win32_OperatingSystem; [pscustomobject]@{ TotalMB = [math]::Round($os.TotalVisibleMemorySize / 1KB, 0); FreeMB = [math]::Round($os.FreePhysicalMemory / 1KB, 0) } | Format-List'
+            Invoke-ProbeIfCommand -CommandName "Get-CimInstance" -Label "页面文件用量" `
+                -Command "Get-CimInstance -ClassName Win32_PageFileUsage | Select-Object Name, AllocatedBaseSize, CurrentUsage, PeakUsage | Format-List"
+            Invoke-Probe -Label "内存占用前 10 的进程" `
+                -Command 'Get-Process | Sort-Object WorkingSet64 -Descending | Select-Object -First 10 Id, ProcessName, @{ Name = "WorkingSetMB"; Expression = { [math]::Round($_.WorkingSet64 / 1MB, 1) } } | Format-Table -AutoSize'
+        }
+        "process" {
+            Invoke-Probe -Label "CPU 累计时间前 15 的进程" `
+                -Command 'Get-Process | Sort-Object CPU -Descending | Select-Object -First 15 Id, ProcessName, CPU, @{ Name = "WorkingSetMB"; Expression = { [math]::Round($_.WorkingSet64 / 1MB, 1) } } | Format-Table -AutoSize'
+            Invoke-Probe -Label "进程总数" `
+                -Command '"进程总数：" + @(Get-Process).Count'
+            Invoke-Probe -Label "句柄数前 5 的进程" `
+                -Command "Get-Process | Sort-Object HandleCount -Descending | Select-Object -First 5 Id, ProcessName, HandleCount | Format-Table -AutoSize"
+        }
+        "network" {
+            Invoke-ProbeIfCommand -CommandName "Get-NetIPConfiguration" -Label "IP 配置" `
+                -Command "Get-NetIPConfiguration | Format-List InterfaceAlias, IPv4Address, IPv6Address, IPv4DefaultGateway, DNSServer"
+            Invoke-ProbeIfCommand -CommandName "Get-NetAdapter" -Label "网卡状态" `
+                -Command "Get-NetAdapter | Select-Object Name, InterfaceDescription, Status, LinkSpeed | Format-Table -AutoSize"
+            Invoke-ProbeIfCommand -CommandName "Get-DnsClientServerAddress" -Label "DNS 服务器" `
+                -Command "Get-DnsClientServerAddress -AddressFamily IPv4 | Select-Object InterfaceAlias, ServerAddresses | Format-Table -AutoSize"
+            Invoke-ProbeIfCommand -CommandName "Get-NetRoute" -Label "默认路由" `
+                -Command 'Get-NetRoute -DestinationPrefix "0.0.0.0/0" | Select-Object InterfaceAlias, NextHop, RouteMetric | Format-Table -AutoSize'
+            Invoke-ProbeIfCommand -CommandName "Get-NetTCPConnection" -Label "监听端口（前 30）" `
+                -Command "Get-NetTCPConnection -State Listen | Sort-Object LocalPort | Select-Object -First 30 LocalAddress, LocalPort, OwningProcess | Format-Table -AutoSize"
+            Invoke-ProbeIfCommand -CommandName "Get-DnsClientCache" -Label "DNS 缓存条数" `
+                -Command '"缓存条数：" + @(Get-DnsClientCache).Count'
+        }
+        "services" {
+            Invoke-ProbeIfCommand -CommandName "Get-Service" -Label "设为自动但未运行的服务" `
+                -Command 'Get-Service | Where-Object { $_.StartType -eq "Automatic" -and $_.Status -ne "Running" } | Select-Object Name, DisplayName, Status | Format-Table -AutoSize'
+            Invoke-ProbeIfCommand -CommandName "Get-Service" -Label "修复相关关键服务的状态" `
+                -Command "Get-Service -Name wuauserv, bits, cryptSvc, msiserver, Spooler, WSearch, fhsvc -ErrorAction SilentlyContinue | Select-Object Name, Status, StartType | Format-Table -AutoSize"
+            Invoke-ProbeIfCommand -CommandName "Get-ScheduledTask" -Label "非微软的就绪计划任务（前 20）" `
+                -Command 'Get-ScheduledTask | Where-Object { $_.State -ne "Disabled" -and $_.TaskPath -notlike "\Microsoft\*" } | Select-Object -First 20 TaskPath, TaskName, State | Format-Table -AutoSize'
+            Invoke-ProbeIfCommand -CommandName "Get-CimInstance" -Label "开机自启项" `
+                -Command "Get-CimInstance -ClassName Win32_StartupCommand | Select-Object Name, Location, Command | Format-Table -AutoSize"
+        }
+        "updates" {
+            Invoke-ProbeIfCommand -CommandName "Get-HotFix" -Label "最近安装的 5 个更新" `
+                -Command "Get-HotFix | Sort-Object InstalledOn -Descending | Select-Object -First 5 HotFixID, Description, InstalledOn | Format-Table -AutoSize"
+            Invoke-ProbeIfCommand -CommandName "Test-Path" -Label "待重启标记（只读注册表）" `
+                -Command '@("HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending", "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired") | ForEach-Object { [pscustomobject]@{ Key = $_; Exists = (Test-Path -Path $_) } } | Format-Table -AutoSize'
+            Invoke-ProbeIfCommand -CommandName "Get-ItemProperty" -Label "待重命名的文件操作数（PendingFileRenameOperations）" `
+                -Command '$key = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager"; $value = (Get-ItemProperty -Path $key -Name PendingFileRenameOperations -ErrorAction SilentlyContinue); if ($null -eq $value) { "没有待重命名的文件操作" } else { "待处理条目数：" + @($value.PendingFileRenameOperations).Count }'
+            Write-SkipRecord -Label "待安装更新清单" `
+                -Reason "查询待安装更新需要联系 Windows Update 服务器，本脚本不发起网络请求；请在 playbook-windows-update-troubleshooting.md 里按步骤确认。"
+        }
+        "security" {
+            Invoke-ProbeIfCommand -CommandName "Get-MpComputerStatus" -Label "Microsoft Defender 状态" `
+                -Command "Get-MpComputerStatus | Select-Object AMServiceEnabled, AntivirusEnabled, RealTimeProtectionEnabled, AntivirusSignatureLastUpdated, QuickScanEndTime | Format-List"
+            Invoke-ProbeIfCommand -CommandName "Get-NetFirewallProfile" -Label "防火墙三个配置档" `
+                -Command "Get-NetFirewallProfile | Select-Object Name, Enabled, DefaultInboundAction, DefaultOutboundAction | Format-Table -AutoSize"
+            Invoke-ProbeIfCommand -CommandName "Get-BitLockerVolume" -Label "BitLocker 卷状态" `
+                -Command "Get-BitLockerVolume | Select-Object MountPoint, VolumeStatus, ProtectionStatus, EncryptionPercentage | Format-Table -AutoSize"
+            Invoke-ProbeIfCommand -CommandName "Confirm-SecureBootUEFI" -Label "安全启动是否开启" `
+                -Command "Confirm-SecureBootUEFI"
+            Invoke-ProbeIfCommand -CommandName "Get-ItemProperty" -Label "UAC 相关策略（只读注册表）" `
+                -Command 'Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" | Select-Object EnableLUA, ConsentPromptBehaviorAdmin, PromptOnSecureDesktop | Format-List'
+            Invoke-ProbeIfCommand -CommandName "Get-ComputerRestorePoint" -Label "最近 5 个系统还原点" `
+                -Command "Get-ComputerRestorePoint | Select-Object -Last 5 SequenceNumber, Description, CreationTime | Format-Table -AutoSize"
+            Invoke-ProbeIfCommand -CommandName "Get-Tpm" -Label "TPM 状态（可能需要管理员）" `
+                -Command "Get-Tpm | Select-Object TpmPresent, TpmReady, TpmEnabled, ManagedAuthLevel | Format-List"
+        }
+        "logs" {
+            Invoke-ProbeIfCommand -CommandName "Get-WinEvent" -Label "近 24 小时 System 日志的严重与错误事件（前 20）" `
+                -Command 'Get-WinEvent -FilterHashtable @{ LogName = "System"; Level = 1, 2; StartTime = (Get-Date).AddHours(-24) } -MaxEvents 20 -ErrorAction SilentlyContinue | Select-Object TimeCreated, Id, ProviderName, @{ Name = "FirstLine"; Expression = { ($_.Message -split "\r?\n")[0] } } | Format-Table -AutoSize -Wrap'
+            Invoke-ProbeIfCommand -CommandName "Get-WinEvent" -Label "近 24 小时 Application 日志的错误事件（前 15）" `
+                -Command 'Get-WinEvent -FilterHashtable @{ LogName = "Application"; Level = 1, 2; StartTime = (Get-Date).AddHours(-24) } -MaxEvents 15 -ErrorAction SilentlyContinue | Select-Object TimeCreated, Id, ProviderName, @{ Name = "FirstLine"; Expression = { ($_.Message -split "\r?\n")[0] } } | Format-Table -AutoSize -Wrap'
+            Invoke-ProbeIfCommand -CommandName "Get-WinEvent" -Label "近 7 天异常关机与蓝屏事件（41 / 1001 / 6008）" `
+                -Command 'Get-WinEvent -FilterHashtable @{ LogName = "System"; Id = 41, 1001, 6008; StartTime = (Get-Date).AddDays(-7) } -MaxEvents 10 -ErrorAction SilentlyContinue | Select-Object TimeCreated, Id, ProviderName | Format-Table -AutoSize'
+            Invoke-Probe -Label "内存转储文件是否存在" `
+                -Command '@("$env:SystemRoot\MEMORY.DMP", "$env:SystemRoot\Minidump") | ForEach-Object { [pscustomobject]@{ Path = $_; Exists = (Test-Path -LiteralPath $_) } } | Format-Table -AutoSize'
+        }
+        "power" {
+            Invoke-ProbeIfCommand -CommandName "Get-CimInstance" -Label "电池状态" `
+                -Command "Get-CimInstance -ClassName Win32_Battery | Select-Object Name, EstimatedChargeRemaining, BatteryStatus, DesignVoltage | Format-List"
+            Invoke-ProbeIfCommand -CommandName "powercfg" -Label "支持的睡眠状态" `
+                -Command "powercfg /a"
+            Invoke-ProbeIfCommand -CommandName "powercfg" -Label "当前电源计划" `
+                -Command "powercfg /getactivescheme"
+            Invoke-ProbeIfCommand -CommandName "Get-CimInstance" -Label "温度传感器（多数机型不上报）" `
+                -Command 'Get-CimInstance -Namespace "root/wmi" -ClassName MSAcpi_ThermalZoneTemperature -ErrorAction SilentlyContinue | Select-Object InstanceName, @{ Name = "TempC"; Expression = { [math]::Round(($_.CurrentTemperature / 10) - 273.15, 1) } } | Format-Table -AutoSize'
+        }
+        default {
+            Write-SkipRecord -Label $Id -Reason "该小节在 Windows 上没有定义探针。"
+        }
+    }
+}
+
+# --- 参数处理 ---------------------------------------------------------------
+
+if ($ListSection.IsPresent) {
+    Show-SectionList -Catalog $SectionCatalog
+    exit 0
+}
+
+$knownIds = @()
+foreach ($entry in $SectionCatalog) {
+    $knownIds += $entry.Id
+}
+
+$wanted = @()
+if ($PSBoundParameters.ContainsKey("Section") -and ($null -ne $Section)) {
+    foreach ($raw in $Section) {
+        foreach ($candidate in ($raw -split ",")) {
+            $trimmed = $candidate.Trim()
+            if ($trimmed.Length -eq 0) {
+                continue
+            }
+            if ($knownIds -notcontains $trimmed) {
+                # 刻意不用 throw：错误信息应该像 install.sh 的 fail() 一样只有一行，
+                # 而不是甩给用户一整段 PowerShell 异常堆栈。
+                [Console]::Error.WriteLine("错误：未知小节：$trimmed。用 -ListSection 查看全部。")
+                exit 1
+            }
+            $wanted += $trimmed
+        }
+    }
+}
+if ($wanted.Count -eq 0) {
+    $wanted = $knownIds
+}
+
+$platform = Get-HostPlatform
+if ($platform -ne "windows") {
+    Write-Status "提示：当前不是 Windows（检测到 $platform）。本脚本的探针面向 Windows，绝大多数检查会被记为 skipped；Linux 与 macOS 请改用 scripts/collect-health.sh。"
+}
+
+# --- 组装输出 ---------------------------------------------------------------
+
+$generatedAt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+$hostName = [Environment]::MachineName
+$userName = [Environment]::UserName
+
+if ($script:OutputFormat -eq "json") {
+    Write-Buffer "{`n"
+    Write-Buffer "  `"schema`": $OutputSchema,`n"
+    Write-Buffer "  `"collector`": `"$(Convert-ToJsonText $CollectorName)`",`n"
+    Write-Buffer "  `"generated_at`": `"$generatedAt`",`n"
+    Write-Buffer "  `"platform`": `"$(Convert-ToJsonText $platform)`",`n"
+    Write-Buffer "  `"read_only`": true,`n"
+    Write-Buffer "  `"network_access`": false,`n"
+    if ($NoIdentity.IsPresent) {
+        Write-Buffer "  `"identity`": null,`n"
+    }
+    else {
+        Write-Buffer "  `"identity`": { `"hostname`": `"$(Convert-ToJsonText $hostName)`", `"user`": `"$(Convert-ToJsonText $userName)`" },`n"
+    }
+    Write-Buffer "  `"sections`": [`n"
+}
+else {
+    Write-Buffer "# 计算机健康证据采集（只读）`n`n"
+    Write-Buffer "- 采集脚本：$CollectorName`n"
+    Write-Buffer "- 采集时间（UTC）：$generatedAt`n"
+    Write-Buffer "- 平台：$platform`n"
+    if (-not $NoIdentity.IsPresent) {
+        Write-Buffer "- 主机：$hostName（用户 $userName）`n"
+    }
+    Write-Buffer "- 全部命令均为只读查询，未发起网络请求。`n`n"
+}
+
+$sectionIndex = 0
+foreach ($sectionId in $wanted) {
+    $title = Get-SectionTitle -Catalog $SectionCatalog -Id $sectionId
+
+    if ($script:OutputFormat -eq "json") {
+        if ($sectionIndex -gt 0) {
+            Write-Buffer ",`n"
+        }
+        Write-Buffer "    {`n"
+        Write-Buffer "      `"id`": `"$(Convert-ToJsonText $sectionId)`",`n"
+        Write-Buffer "      `"title`": `"$(Convert-ToJsonText $title)`",`n"
+        Write-Buffer "      `"probes`": [`n"
+    }
+    else {
+        Write-Buffer "## $title（$sectionId）`n`n"
+    }
+
+    $script:ProbeIndex = 0
+    Invoke-SectionProbe -Id $sectionId
+
+    if ($script:OutputFormat -eq "json") {
+        Write-Buffer "`n      ]`n"
+        Write-Buffer "    }"
+    }
+    $sectionIndex = $sectionIndex + 1
+}
+
+if ($script:OutputFormat -eq "json") {
+    Write-Buffer "`n  ]`n"
+    Write-Buffer "}`n"
+}
+else {
+    Write-Buffer "---`n`n"
+    Write-Buffer "共 $sectionIndex 个小节、$($script:ProbeCount) 项检查，其中 $($script:SkipCount) 项主动跳过、$($script:ProbeFailureCount) 项命令返回非零。`n"
+}
+
+if ($null -ne $script:ProbeRunspace) {
+    $script:ProbeRunspace.Dispose()
+    $script:ProbeRunspace = $null
+}
+
+$document = $script:Buffer.ToString()
+
+if ([string]::IsNullOrEmpty($OutputPath)) {
+    [Console]::Out.Write($document)
+}
+else {
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    $temporary = "$OutputPath.tmp"
+    [IO.File]::WriteAllText($temporary, $document, $utf8NoBom)
+    Move-Item -LiteralPath $temporary -Destination $OutputPath -Force
+    Write-Status "已写入 $OutputPath（$sectionIndex 个小节，$($script:ProbeCount) 项检查，$($script:SkipCount) 项跳过，$($script:ProbeFailureCount) 项返回非零）"
+}
+
+exit 0

--- a/scripts/collect-health.sh
+++ b/scripts/collect-health.sh
@@ -1,0 +1,499 @@
+#!/usr/bin/env bash
+# 只读采集一台 Linux / macOS 机器的健康证据，输出结构化 JSON 或 Markdown。
+#
+# 安全边界（与 skills/computer-repair-skill/references/safety-policy.md 一致）：
+#   * 只执行查询类命令：不安装、不删除、不重启服务、不改配置、不写注册表或系统目录。
+#   * 不发起任何网络请求；需要联网刷新元数据的检查会被显式标记为 skipped。
+#   * 输出前逐行过滤，凡含 password / token / secret 等关键字的行整行替换为占位符。
+#   * 除 --output 指定的文件外不写入任何路径。
+#
+# 这个脚本是可选的辅助工具。Skill 的核心仍然是 Markdown Playbook：
+# 采集到的证据只是给 Agent 和维修工程师看的输入，任何变更动作仍由 Playbook 驱动。
+set -uo pipefail
+
+collector_name="collect-health.sh"
+schema=1
+
+format="json"
+output=""
+selected_sections=""
+probe_timeout=20
+include_identity=1
+list_only=0
+
+usage() {
+  cat <<'EOF'
+用法: ./scripts/collect-health.sh [选项]
+
+选项:
+      --format <json|markdown>  输出格式，默认 json
+      --output <path>           写入指定文件；缺省写标准输出
+      --sections <a,b,c>        只采集指定小节，逗号分隔；缺省采集全部
+      --list-sections           列出可用小节后退出
+      --timeout <秒>            单条命令超时，默认 20（需要 timeout/gtimeout）
+      --no-identity             报告头部不记录主机名与用户名
+                                （注意：uname -a 等探针的原始输出里仍可能出现主机名）
+  -h, --help                    显示帮助
+
+示例:
+  ./scripts/collect-health.sh --format markdown
+  ./scripts/collect-health.sh --sections overview,storage,network --output health.json
+EOF
+}
+
+fail() {
+  printf '错误：%s\n' "$1" >&2
+  exit 1
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --format)
+      (($# >= 2)) || fail "--format 缺少参数。"
+      format="$2"
+      shift 2
+      ;;
+    --output)
+      (($# >= 2)) || fail "--output 缺少参数。"
+      output="$2"
+      shift 2
+      ;;
+    --sections)
+      (($# >= 2)) || fail "--sections 缺少参数。"
+      selected_sections="$2"
+      shift 2
+      ;;
+    --timeout)
+      (($# >= 2)) || fail "--timeout 缺少参数。"
+      probe_timeout="$2"
+      shift 2
+      ;;
+    --no-identity)
+      include_identity=0
+      shift
+      ;;
+    --list-sections)
+      list_only=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "未知参数：$1。用 --help 查看用法。"
+      ;;
+  esac
+done
+
+case "$format" in
+  json | markdown) ;;
+  *) fail "不支持的 --format：${format}（可选 json 或 markdown）" ;;
+esac
+
+case "$probe_timeout" in
+  '' | *[!0-9]*) fail "--timeout 必须是正整数秒数。" ;;
+  *) ((probe_timeout > 0)) || fail "--timeout 必须大于 0。" ;;
+esac
+
+# 小节定义：id|标题
+section_catalog="overview|系统与启动概览
+hardware|硬件与固件
+storage|存储与文件系统
+memory|内存与交换
+process|进程占用排行
+network|网络配置与监听
+services|服务与计划任务
+updates|系统更新状态（只读本地缓存）
+security|安全基线开关
+logs|近期错误日志与崩溃报告
+power|电源、电池与温度"
+
+section_ids() {
+  printf '%s\n' "$section_catalog" | awk -F '|' '{ print $1 }'
+}
+
+section_title() {
+  printf '%s\n' "$section_catalog" | awk -F '|' -v id="$1" '$1 == id { print $2 }'
+}
+
+if ((list_only == 1)); then
+  printf '%s\n' "可用小节（--sections 用逗号连接多个 id）："
+  printf '%s\n' "$section_catalog" | awk -F '|' '{ printf "  %-10s %s\n", $1, $2 }'
+  exit 0
+fi
+
+if [[ -n "$selected_sections" ]]; then
+  wanted="$(printf '%s' "$selected_sections" | tr ',' '\n' | awk 'NF')"
+  while IFS= read -r candidate; do
+    [[ -n "$candidate" ]] || continue
+    if ! section_ids | grep -Fxq -- "$candidate"; then
+      fail "未知小节：${candidate}。用 --list-sections 查看全部。"
+    fi
+  done <<EOF
+$wanted
+EOF
+else
+  wanted="$(section_ids)"
+fi
+
+# --- 平台与执行工具 ---------------------------------------------------------
+
+uname_s="$(uname -s 2>/dev/null || printf 'unknown')"
+case "$uname_s" in
+  Linux) platform="linux" ;;
+  Darwin) platform="macos" ;;
+  *) fail "本脚本只覆盖 Linux 与 macOS；当前系统是 ${uname_s}。Windows 请改用 scripts/collect-health.ps1。" ;;
+esac
+
+timeout_bin=""
+if command -v timeout >/dev/null 2>&1; then
+  timeout_bin="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  timeout_bin="gtimeout"
+fi
+
+# --- 输出工具 ---------------------------------------------------------------
+
+# 整行丢弃可能含凭据的输出。宁可少给一行证据，也不要把秘密写进报告。
+redact() {
+  awk '
+    {
+      lowered = tolower($0)
+      if (lowered ~ /password|passwd|secret|token|api[_-]?key|apikey|access[_-]?key|bearer|credential|private key|psk/) {
+        print "[已按只读采集策略移除可能含凭据的一行]"
+      } else {
+        print
+      }
+    }'
+}
+
+# 先用 tr 去掉控制字符（保留制表与换行），再交给 awk 做 JSON 转义。
+json_escape() {
+  tr -d '\000-\010\013\014\016-\037' | awk '
+    BEGIN { ORS = "" }
+    {
+      line = $0
+      gsub(/\\/, "\\\\", line)
+      gsub(/"/, "\\\"", line)
+      gsub(/\t/, "\\t", line)
+      printf "%s%s", (NR > 1 ? "\\n" : ""), line
+    }'
+}
+
+json_inline() {
+  printf '%s' "$1" | json_escape
+}
+
+# 缓冲区里存的是真实换行，最后用 printf '%s' 原样输出。
+# 不能用 printf '%b' + 字面 \n：那样探针输出里的反斜杠（例如 \\wsl$ 或 C:\Users）
+# 会被二次解释，JSON 转义结果直接被破坏。
+nl=$'\n'
+buffer=""
+append() {
+  buffer="$buffer$1"
+}
+
+# --- 探针 -------------------------------------------------------------------
+
+probe_index=0
+probe_count=0
+probe_failures=0
+skipped_count=0
+
+# probe <说明> <命令>：执行只读命令并记录退出码与输出。
+probe() {
+  probe_label="$1"
+  probe_command="$2"
+
+  if [[ -n "$timeout_bin" ]]; then
+    probe_output="$("$timeout_bin" "$probe_timeout" sh -c "$probe_command" 2>&1)"
+    probe_status=$?
+  else
+    probe_output="$(sh -c "$probe_command" 2>&1)"
+    probe_status=$?
+  fi
+
+  probe_output="$(printf '%s\n' "$probe_output" | redact)"
+  probe_count=$((probe_count + 1))
+  ((probe_status == 0)) || probe_failures=$((probe_failures + 1))
+
+  if [[ "$format" == "json" ]]; then
+    if ((probe_index > 0)); then
+      append $',\n'
+    fi
+    append $'      {\n'
+    append "        \"label\": \"$(json_inline "$probe_label")\",$nl"
+    append "        \"command\": \"$(json_inline "$probe_command")\",$nl"
+    append "        \"exit_code\": $probe_status,$nl"
+    append "        \"output\": \"$(printf '%s' "$probe_output" | json_escape)\"$nl"
+    append '      }'
+  else
+    append "### $probe_label$nl$nl"
+    append $'```text\n'
+    append "\$ $probe_command$nl"
+    append "$probe_output$nl"
+    append $'```\n\n'
+    append "退出码：$probe_status$nl$nl"
+  fi
+  probe_index=$((probe_index + 1))
+}
+
+# skip <说明> <原因>：记录一条被主动跳过的检查，说明为什么不做。
+skip() {
+  skipped_count=$((skipped_count + 1))
+  probe_count=$((probe_count + 1))
+  if [[ "$format" == "json" ]]; then
+    if ((probe_index > 0)); then
+      append $',\n'
+    fi
+    append $'      {\n'
+    append "        \"label\": \"$(json_inline "$1")\",$nl"
+    append $'        "command": null,\n'
+    append $'        "exit_code": null,\n'
+    append "        \"output\": \"$(json_inline "已跳过：$2")\"$nl"
+    append '      }'
+  else
+    append "### $1$nl$nl"
+    append "已跳过：$2$nl$nl"
+  fi
+  probe_index=$((probe_index + 1))
+}
+
+# 只有命令存在时才执行，否则记录为跳过，避免把 "command not found" 当成故障。
+probe_if() {
+  if command -v "$1" >/dev/null 2>&1; then
+    probe "$2" "$3"
+  else
+    skip "$2" "本机没有 $1，无法采集这一项。"
+  fi
+}
+
+collect_linux_section() {
+  case "$1" in
+    overview)
+      probe "内核与架构" "uname -a"
+      probe "发行版信息" "cat /etc/os-release"
+      probe "运行时长与负载" "uptime"
+      probe "当前时间与时区" "date -u; date"
+      probe_if timedatectl "时间同步状态" "timedatectl status"
+      ;;
+    hardware)
+      probe_if lscpu "CPU 概览" "lscpu"
+      probe "CPU 型号" "grep -m 1 'model name' /proc/cpuinfo"
+      probe "内存总量" "grep -E 'MemTotal|SwapTotal' /proc/meminfo"
+      probe "主板与机型" "cat /sys/class/dmi/id/sys_vendor /sys/class/dmi/id/product_name /sys/class/dmi/id/bios_version"
+      ;;
+    storage)
+      probe "文件系统占用" "df -hT"
+      probe_if lsblk "块设备拓扑" "lsblk -o NAME,SIZE,TYPE,FSTYPE,MOUNTPOINT"
+      probe "inode 占用" "df -i"
+      probe_if findmnt "只读挂载检查" "findmnt -o TARGET,SOURCE,FSTYPE,OPTIONS"
+      ;;
+    memory)
+      probe "内存与交换用量" "free -m"
+      probe_if swapon "交换设备" "swapon --show"
+      probe "内存压力（PSI）" "cat /proc/pressure/memory"
+      probe "OOM 记录" "grep -i -c 'out of memory' /var/log/syslog /var/log/messages 2>/dev/null || echo '无法读取系统日志（通常需要权限）'"
+      ;;
+    process)
+      probe "CPU 占用前 15" "ps -eo pid,ppid,pcpu,pmem,etime,comm --sort=-pcpu | head -n 16"
+      probe "内存占用前 15" "ps -eo pid,ppid,pcpu,pmem,rss,comm --sort=-pmem | head -n 16"
+      probe "进程总数" "ps -e --no-headers | wc -l"
+      ;;
+    network)
+      probe_if ip "接口地址" "ip -brief address"
+      probe_if ip "路由表" "ip route"
+      probe "DNS 配置" "cat /etc/resolv.conf"
+      probe_if resolvectl "解析器状态" "resolvectl status | head -n 40"
+      probe_if ss "监听端口" "ss -tuln"
+      ;;
+    services)
+      probe_if systemctl "失败的单元" "systemctl --failed --no-pager --no-legend"
+      probe_if systemctl "最近的计划任务" "systemctl list-timers --all --no-pager | head -n 15"
+      probe "用户 crontab 是否存在" "crontab -l >/dev/null 2>&1 && echo '存在用户 crontab' || echo '没有用户 crontab 或无权读取'"
+      ;;
+    updates)
+      if command -v apt >/dev/null 2>&1; then
+        probe "可升级软件包（读本地 apt 缓存，不联网）" "apt list --upgradable 2>/dev/null | head -n 40"
+        probe "apt 缓存最后更新时间" "ls -l --time-style=long-iso /var/lib/apt/periodic 2>/dev/null || stat -c '%y %n' /var/lib/apt/lists 2>/dev/null"
+      elif command -v pacman >/dev/null 2>&1; then
+        probe "可升级软件包（只查本地数据库）" "pacman -Qu | head -n 40"
+      elif command -v dnf >/dev/null 2>&1; then
+        probe "可升级软件包（--cacheonly，不联网）" "dnf --cacheonly check-update | head -n 40"
+      else
+        skip "系统更新状态" "未识别到 apt / pacman / dnf，且本脚本不会联网刷新元数据。"
+      fi
+      ;;
+    security)
+      probe_if systemctl "防火墙服务状态" "systemctl is-active ufw firewalld nftables 2>&1"
+      probe_if nft "nftables 规则条数" "nft list ruleset 2>&1 | wc -l"
+      probe "SELinux 状态" "command -v getenforce >/dev/null 2>&1 && getenforce || echo '本机没有 getenforce'"
+      probe "已启用的 LSM" "cat /sys/kernel/security/lsm"
+      probe "待重启标记" "test -e /var/run/reboot-required && echo '需要重启' || echo '无重启标记'"
+      ;;
+    logs)
+      probe_if journalctl "本次启动的 error 级日志（末 30 行）" "journalctl -p 3 -b --no-pager 2>&1 | tail -n 30"
+      probe_if journalctl "上次启动的 error 级日志（末 20 行）" "journalctl -p 3 -b -1 --no-pager 2>&1 | tail -n 20"
+      probe "内核错误与告警" "dmesg --level=err,warn 2>&1 | tail -n 20"
+      ;;
+    power)
+      probe "电池状态" "grep -H . /sys/class/power_supply/*/capacity /sys/class/power_supply/*/status 2>/dev/null || echo '未发现电池（可能是台式机）'"
+      probe "CPU 温度" "grep -H . /sys/class/thermal/thermal_zone*/temp 2>/dev/null || echo '无法读取温度传感器'"
+      probe_if sensors "传感器读数" "sensors 2>&1 | head -n 30"
+      ;;
+    *)
+      skip "$1" "该小节在 Linux 上没有定义探针。"
+      ;;
+  esac
+}
+
+collect_macos_section() {
+  case "$1" in
+    overview)
+      probe "系统版本" "sw_vers"
+      probe "内核与架构" "uname -a"
+      probe "运行时长与负载" "uptime"
+      probe "上次启动时间" "sysctl -n kern.boottime"
+      probe "当前时间与时区" "date -u; date; systemsetup -gettimezone 2>/dev/null || true"
+      ;;
+    hardware)
+      probe "CPU 型号" "sysctl -n machdep.cpu.brand_string"
+      probe "内存总量（字节）" "sysctl -n hw.memsize"
+      probe "机型与序列信息" "system_profiler SPHardwareDataType 2>&1 | head -n 25"
+      ;;
+    storage)
+      probe "文件系统占用" "df -h"
+      probe "磁盘与分区" "diskutil list"
+      probe "APFS 容器信息" "diskutil apfs list 2>&1 | head -n 40"
+      ;;
+    memory)
+      probe "虚拟内存统计" "vm_stat"
+      probe "交换用量" "sysctl -n vm.swapusage"
+      probe "内存压力" "memory_pressure -Q 2>&1 | head -n 20"
+      ;;
+    process)
+      probe "CPU 占用前 15" "ps -Ao pid,ppid,pcpu,pmem,etime,comm -r | head -n 16"
+      probe "内存占用前 15" "ps -Ao pid,ppid,pcpu,pmem,rss,comm -m | head -n 16"
+      probe "进程总数" "ps -A | wc -l"
+      ;;
+    network)
+      probe "接口地址" "ifconfig -a"
+      probe "路由表" "netstat -rn | head -n 25"
+      probe "DNS 解析器配置" "scutil --dns | head -n 40"
+      probe "网络硬件端口" "networksetup -listallhardwareports"
+      probe "监听端口" "netstat -an -p tcp | head -n 30"
+      ;;
+    services)
+      probe "当前用户的 launchd 任务" "launchctl list | head -n 30"
+      probe "系统级 launchd 任务数" "launchctl print system 2>/dev/null | head -n 20 || echo '需要更高权限，已跳过详细输出'"
+      ;;
+    updates)
+      skip "系统更新状态" "softwareupdate --list 必须联网，本脚本不发起网络请求；请在 Playbook 里由工程师确认后手动执行。"
+      probe "最近一次成功检查更新的时间（读本地偏好）" "defaults read /Library/Preferences/com.apple.SoftwareUpdate LastFullSuccessfulDate 2>&1"
+      ;;
+    security)
+      probe "系统完整性保护" "csrutil status"
+      probe "Gatekeeper 状态" "spctl --status 2>&1"
+      probe "FileVault 状态" "fdesetup isactive 2>&1"
+      probe "应用防火墙状态" "/usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate 2>&1"
+      ;;
+    logs)
+      probe "最近的崩溃报告" "ls -lt ~/Library/Logs/DiagnosticReports 2>/dev/null | head -n 15 || echo '没有用户级崩溃报告'"
+      probe "系统级崩溃报告" "ls -lt /Library/Logs/DiagnosticReports 2>/dev/null | head -n 15 || echo '没有系统级崩溃报告或无权读取'"
+      probe "近期内核消息" "syslog -k Level Nem 2>/dev/null | tail -n 20 || echo '无法读取内核消息'"
+      ;;
+    power)
+      probe "电池与电源" "pmset -g batt"
+      probe "阻止睡眠的断言" "pmset -g assertions 2>&1 | head -n 25"
+      probe "电源与循环次数" "system_profiler SPPowerDataType 2>&1 | head -n 40"
+      ;;
+    *)
+      skip "$1" "该小节在 macOS 上没有定义探针。"
+      ;;
+  esac
+}
+
+# --- 组装输出 ---------------------------------------------------------------
+
+generated_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+host_name="$(hostname 2>/dev/null || printf 'unknown')"
+user_name="$(id -un 2>/dev/null || printf 'unknown')"
+
+if [[ "$format" == "json" ]]; then
+  append $'{\n'
+  append "  \"schema\": $schema,$nl"
+  append "  \"collector\": \"$(json_inline "$collector_name")\",$nl"
+  append "  \"generated_at\": \"$generated_at\",$nl"
+  append "  \"platform\": \"$platform\",$nl"
+  append $'  "read_only": true,\n'
+  append $'  "network_access": false,\n'
+  if ((include_identity == 1)); then
+    append "  \"identity\": { \"hostname\": \"$(json_inline "$host_name")\", \"user\": \"$(json_inline "$user_name")\" },$nl"
+  else
+    append $'  "identity": null,\n'
+  fi
+  append $'  "sections": [\n'
+else
+  append "# 计算机健康证据采集（只读）$nl$nl"
+  append "- 采集脚本：$collector_name$nl"
+  append "- 采集时间（UTC）：$generated_at$nl"
+  append "- 平台：$platform$nl"
+  if ((include_identity == 1)); then
+    append "- 主机：${host_name}（用户 ${user_name}）$nl"
+  fi
+  append "- 全部命令均为只读查询，未发起网络请求。$nl$nl"
+fi
+
+section_index=0
+while IFS= read -r section_id; do
+  [[ -n "$section_id" ]] || continue
+  title="$(section_title "$section_id")"
+
+  if [[ "$format" == "json" ]]; then
+    if ((section_index > 0)); then
+      append $',\n'
+    fi
+    append $'    {\n'
+    append "      \"id\": \"$(json_inline "$section_id")\",$nl"
+    append "      \"title\": \"$(json_inline "$title")\",$nl"
+    append $'      "probes": [\n'
+  else
+    append "## ${title}（${section_id}）$nl$nl"
+  fi
+
+  probe_index=0
+  if [[ "$platform" == "linux" ]]; then
+    collect_linux_section "$section_id"
+  else
+    collect_macos_section "$section_id"
+  fi
+
+  if [[ "$format" == "json" ]]; then
+    append $'\n      ]\n'
+    append '    }'
+  fi
+  section_index=$((section_index + 1))
+done <<EOF
+$wanted
+EOF
+
+if [[ "$format" == "json" ]]; then
+  append $'\n  ]\n'
+  append $'}\n'
+else
+  append "---$nl$nl"
+  append "共 $section_index 个小节、$probe_count 项检查，其中 $skipped_count 项主动跳过、$probe_failures 项命令返回非零。$nl"
+fi
+
+if [[ -n "$output" ]]; then
+  output_tmp="$output.tmp.$$"
+  printf '%s' "$buffer" >"$output_tmp" || fail "无法写入 $output_tmp"
+  mv -- "$output_tmp" "$output" || fail "无法写入 $output"
+  printf '已写入 %s（%s 个小节，%s 项检查，%s 项跳过，%s 项返回非零）\n' \
+    "$output" "$section_index" "$probe_count" "$skipped_count" "$probe_failures" >&2
+else
+  printf '%s' "$buffer"
+fi
+
+exit 0

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,17 +1,73 @@
-﻿[CmdletBinding()]
+﻿# PositionalBinding = $false：所有参数一律具名。
+# 否则 `-Target claude foo` 这类手滑会把多余的位置参数静默吞掉，
+# 而 scripts/install.sh 是明确报错的，两个安装器的行为必须一致。
+[CmdletBinding(PositionalBinding = $false)]
 param(
-    [ValidateSet("codex", "claude", "agents", "custom")]
+    [ValidateSet(
+        "codex", "claude", "claude-code", "cursor", "gemini-cli", "github-copilot",
+        "windsurf", "opencode", "openclaw", "agents", "universal", "antigravity",
+        "augment", "qwen-code", "trae", "roo", "crush", "goose", "droid",
+        "continue", "openhands", "custom")]
     [string]$Target = "codex",
 
     [string]$Destination,
 
-    [switch]$Force
+    [string]$BackupDir,
+
+    [switch]$Verify,
+
+    [switch]$Uninstall,
+
+    [switch]$ListTarget,
+
+    [switch]$Link,
+
+    [switch]$Force,
+
+    [switch]$Purge,
+
+    [switch]$DryRun,
+
+    [switch]$Quiet
 )
+
+# 把 computer-repair-skill 安装到某个 Agent 的 Skills 根目录。
+#
+# 设计约束（与 scripts/install.sh 保持一致）：
+#   * 默认绝不覆盖已存在的安装，必须显式 -Force。
+#   * 先完整复制到临时目录再一次性 Move-Item 生效，失败自动回滚。
+#   * 安装后写出与 Bash 版逐行同构的清单，两个安装器可以互相校验。
+#   * 兼容 Windows PowerShell 5.1：不使用三元运算符、?? 以及 .NET Core 专属 API。
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+# 预期内的失败（尚未安装、清单不匹配、参数互斥……）必须像 scripts/install.sh 的 fail()
+# 一样，输出一行 "错误：…" 到 stderr 然后以 1 退出，而不是把 PowerShell 的异常堆栈
+# 甩到用户脸上。两个安装器的失败体验必须一致。
+#
+# 这里用脚本作用域的 trap 而不是在末尾包一层 try/catch：本脚本的参数校验散落在函数
+# 定义之间的主体代码里，无法被单个 try 块包住，而 trap 能同时覆盖主体和三个入口函数。
+# trap 也不会打断函数内部已有的 try/finally 回滚 —— finally 在异常向外传播时先执行，
+# trap 才拿到控制权。
+trap {
+    [Console]::Error.WriteLine("错误：" + $_.Exception.Message)
+    exit 1
+}
+
 $SkillName = "computer-repair-skill"
+$ManifestName = ".computer-repair-skill-install.json"
+$BackupDirName = ".computer-repair-skill-backups"
+$ManifestSchema = 1
+
+$script:QuietOutput = $Quiet.IsPresent
+
+# 把开关的取值提升到脚本作用域：函数里显式引用 $script:* 比依赖动态作用域更清晰，
+# 也让 PSScriptAnalyzer 的 PSReviewUnusedParameter 能正确识别这些参数确实被使用。
+$script:UseForce = $Force.IsPresent
+$script:UseLink = $Link.IsPresent
+$script:IsDryRun = $DryRun.IsPresent
+$script:UsePurge = $Purge.IsPresent
 
 function Write-Status {
     <# 输出面向用户的进度信息。
@@ -21,11 +77,13 @@ function Write-Status {
     提示文字混进函数返回值。直接写 Console 的标准输出最可控。 #>
     param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Message)
 
-    [Console]::Out.WriteLine($Message)
+    if (-not $script:QuietOutput) {
+        [Console]::Out.WriteLine($Message)
+    }
 }
 
 function Expand-InstallPath {
-    <# 将环境变量、用户目录和相对路径转换为可审计的绝对路径。 #>
+    <# 将环境变量、用户目录和相对路径转换为可审计的绝对路径；不触碰磁盘。 #>
     param([Parameter(Mandatory = $true)][string]$Path)
 
     $userProfile = [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
@@ -45,6 +103,75 @@ function Expand-InstallPath {
     return [IO.Path]::GetFullPath($expanded)
 }
 
+function Get-ConfigHome {
+    <# XDG 风格的配置根目录，缺省回落到 ~/.config，与 Bash 版一致。 #>
+    $userProfile = [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
+    if ($env:XDG_CONFIG_HOME) {
+        return $env:XDG_CONFIG_HOME
+    }
+    return (Join-Path $userProfile ".config")
+}
+
+function Get-PresetRoot {
+    <# 各 Agent 的默认全局 Skills 根目录；custom 返回空串表示必须显式给出目录。 #>
+    param([Parameter(Mandatory = $true)][string]$AgentTarget)
+
+    $userProfile = [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
+
+    switch ($AgentTarget) {
+        "codex" {
+            if ($env:CODEX_HOME) { return (Join-Path $env:CODEX_HOME "skills") }
+            return (Join-Path (Join-Path $userProfile ".codex") "skills")
+        }
+        { $_ -in @("claude", "claude-code") } {
+            if ($env:CLAUDE_HOME) { return (Join-Path $env:CLAUDE_HOME "skills") }
+            return (Join-Path (Join-Path $userProfile ".claude") "skills")
+        }
+        "cursor" { return (Join-Path (Join-Path $userProfile ".cursor") "skills") }
+        "gemini-cli" { return (Join-Path (Join-Path $userProfile ".gemini") "skills") }
+        "github-copilot" { return (Join-Path (Join-Path $userProfile ".copilot") "skills") }
+        "windsurf" { return (Join-Path (Join-Path $userProfile ".codeium\windsurf") "skills") }
+        "opencode" { return (Join-Path (Join-Path (Get-ConfigHome) "opencode") "skills") }
+        "openclaw" { return (Join-Path (Join-Path $userProfile ".openclaw") "skills") }
+        "agents" { return (Join-Path (Join-Path $userProfile ".agents") "skills") }
+        "universal" { return (Join-Path (Join-Path (Get-ConfigHome) "agents") "skills") }
+        "antigravity" { return (Join-Path (Join-Path $userProfile ".gemini\antigravity") "skills") }
+        "augment" { return (Join-Path (Join-Path $userProfile ".augment") "skills") }
+        "qwen-code" { return (Join-Path (Join-Path $userProfile ".qwen") "skills") }
+        "trae" { return (Join-Path (Join-Path $userProfile ".trae") "skills") }
+        "roo" { return (Join-Path (Join-Path $userProfile ".roo") "skills") }
+        "crush" { return (Join-Path (Join-Path (Get-ConfigHome) "crush") "skills") }
+        "goose" { return (Join-Path (Join-Path (Get-ConfigHome) "goose") "skills") }
+        "droid" { return (Join-Path (Join-Path $userProfile ".factory") "skills") }
+        "continue" { return (Join-Path (Join-Path $userProfile ".continue") "skills") }
+        "openhands" { return (Join-Path (Join-Path $userProfile ".openhands") "skills") }
+        "custom" { return "" }
+        default { throw "不支持的 Target：$AgentTarget" }
+    }
+}
+
+function Show-TargetList {
+    <# 打印全部预设及其解析后的目录，方便用户核对再安装。 #>
+    $names = @(
+        "codex", "claude", "claude-code", "cursor", "gemini-cli", "github-copilot",
+        "windsurf", "opencode", "openclaw", "agents", "universal", "antigravity",
+        "augment", "qwen-code", "trae", "roo", "crush", "goose", "droid",
+        "continue", "openhands", "custom")
+
+    Write-Status ("{0,-16} {1}" -f "预设", "全局 Skills 根目录")
+    foreach ($name in $names) {
+        $root = Get-PresetRoot -AgentTarget $name
+        if ([string]::IsNullOrEmpty($root)) {
+            Write-Status ("{0,-16} {1}" -f $name, "（必须配合 -Destination）")
+        }
+        else {
+            Write-Status ("{0,-16} {1}" -f $name, (Expand-InstallPath $root))
+        }
+    }
+    Write-Status ""
+    Write-Status "项目级安装请改用 -Destination，例如 -Destination .\.claude\skills。"
+}
+
 function Get-SkillsRoot {
     <# 按 Agent 预设选择 Skills 根目录；自定义模式必须显式给出目录。 #>
     param(
@@ -56,26 +183,147 @@ function Get-SkillsRoot {
         return Expand-InstallPath $CustomDestination
     }
 
-    $userProfile = [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
-    switch ($AgentTarget) {
-        "codex" {
-            $agentHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $userProfile ".codex" }
+    $root = Get-PresetRoot -AgentTarget $AgentTarget
+    if ([string]::IsNullOrEmpty($root)) {
+        throw "Target 为 custom 时必须提供 -Destination。"
+    }
+    return Expand-InstallPath $root
+}
+
+function Test-IsReparsePoint {
+    <# 判断路径是否为符号链接或目录联接。 #>
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $false
+    }
+    $item = Get-Item -LiteralPath $Path -Force
+    return (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0)
+}
+
+function Get-LinkTargetPath {
+    <# 读取链接指向的路径；PowerShell 5.1 可能返回数组，这里统一成字符串。 #>
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $item = Get-Item -LiteralPath $Path -Force
+    $value = $item.Target
+    if ($null -eq $value) {
+        return ""
+    }
+    if ($value -is [array]) {
+        if ($value.Count -eq 0) {
+            return ""
         }
-        "claude" {
-            $agentHome = if ($env:CLAUDE_HOME) { $env:CLAUDE_HOME } else { Join-Path $userProfile ".claude" }
-        }
-        "agents" {
-            $agentHome = Join-Path $userProfile ".agents"
-        }
-        "custom" {
-            throw "Target 为 custom 时必须提供 -Destination。"
-        }
-        default {
-            throw "不支持的 Target：$AgentTarget"
+        return [string]$value[0]
+    }
+    return [string]$value
+}
+
+function Get-PayloadFileList {
+    <# 列出目录下全部普通文件的相对路径，按序数排序以匹配 Bash 版的 LC_ALL=C sort。 #>
+    param([Parameter(Mandatory = $true)][string]$Root)
+
+    $rootFull = [IO.Path]::GetFullPath($Root)
+    if (-not $rootFull.EndsWith([string][IO.Path]::DirectorySeparatorChar)) {
+        $rootFull = $rootFull + [IO.Path]::DirectorySeparatorChar
+    }
+
+    $collected = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($file in (Get-ChildItem -LiteralPath $Root -Recurse -File -Force)) {
+        $collected.Add($file.FullName.Substring($rootFull.Length).Replace("\", "/"))
+    }
+    $collected.Sort([System.StringComparer]::Ordinal)
+    return $collected.ToArray()
+}
+
+function Get-DigestList {
+    <# 生成 "相对路径 sha256" 数组；清单以空格分隔，因此强制校验文件名字符集。 #>
+    param([Parameter(Mandatory = $true)][string]$Root)
+
+    foreach ($entry in (Get-ChildItem -LiteralPath $Root -Recurse -Force)) {
+        if (($entry.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+            throw "Skill 载荷中存在链接，清单无法保证可复现：$($entry.FullName)"
         }
     }
 
-    return Expand-InstallPath (Join-Path $agentHome "skills")
+    $lines = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($rel in @(Get-PayloadFileList -Root $Root)) {
+        if ($rel -notmatch '^[A-Za-z0-9._/-]+$') {
+            throw "文件名含清单不支持的字符（仅允许字母、数字、点、下划线、连字符和斜杠）：$rel"
+        }
+        $full = Join-Path $Root ($rel -replace '/', [IO.Path]::DirectorySeparatorChar)
+        $hash = (Get-FileHash -LiteralPath $full -Algorithm SHA256).Hash.ToLowerInvariant()
+        $lines.Add("$rel $hash")
+    }
+    return $lines.ToArray()
+}
+
+function Convert-ToJsonString {
+    <# 只需转义反斜杠和双引号：其余字段都是路径、版本号或十六进制摘要。 #>
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
+
+    return $Value.Replace("\", "\\").Replace('"', '\"')
+}
+
+function Write-InstallManifest {
+    <# 手写 JSON 而不用 ConvertTo-Json：必须与 Bash 版逐行同构，
+       这样 install.sh --verify 也能解析本脚本写出的清单。 #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Mode,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$DigestList,
+        [Parameter(Mandatory = $true)][string]$SourceDirectory,
+        [Parameter(Mandatory = $true)][string]$TargetDirectory,
+        [Parameter(Mandatory = $true)][string]$SkillVersion,
+        [AllowEmptyString()][string]$SourceCommit = ""
+    )
+
+    $builder = New-Object System.Text.StringBuilder
+    [void]$builder.Append("{`n")
+    [void]$builder.Append("  `"schema`": $ManifestSchema,`n")
+    [void]$builder.Append("  `"skill`": `"$(Convert-ToJsonString $SkillName)`",`n")
+    [void]$builder.Append("  `"version`": `"$(Convert-ToJsonString $SkillVersion)`",`n")
+    [void]$builder.Append("  `"install_mode`": `"$(Convert-ToJsonString $Mode)`",`n")
+    [void]$builder.Append("  `"installed_at`": `"$((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'))`",`n")
+    [void]$builder.Append("  `"installer`": `"scripts/install.ps1`",`n")
+    [void]$builder.Append("  `"source_dir`": `"$(Convert-ToJsonString $SourceDirectory)`",`n")
+    if ([string]::IsNullOrEmpty($SourceCommit)) {
+        [void]$builder.Append("  `"source_commit`": null,`n")
+    }
+    else {
+        [void]$builder.Append("  `"source_commit`": `"$(Convert-ToJsonString $SourceCommit)`",`n")
+    }
+    [void]$builder.Append("  `"target_path`": `"$(Convert-ToJsonString $TargetDirectory)`",`n")
+    [void]$builder.Append("  `"file_count`": $($DigestList.Count),`n")
+    [void]$builder.Append("  `"files`": [`n")
+    for ($i = 0; $i -lt $DigestList.Count; $i++) {
+        $parts = $DigestList[$i].Split(" ")
+        $comma = ","
+        if ($i -eq ($DigestList.Count - 1)) {
+            $comma = ""
+        }
+        [void]$builder.Append("    { `"path`": `"$($parts[0])`", `"sha256`": `"$($parts[1])`" }$comma`n")
+    }
+    [void]$builder.Append("  ]`n")
+    [void]$builder.Append("}`n")
+
+    $temporary = "$Path.tmp"
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [IO.File]::WriteAllText($temporary, $builder.ToString(), $utf8NoBom)
+    Move-Item -LiteralPath $temporary -Destination $Path -Force
+}
+
+function Read-InstallManifest {
+    <# 读取清单并返回 PSCustomObject；缺字段时给出明确错误而不是抛 StrictMode 异常。 #>
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $manifest = Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-Json
+    foreach ($field in @("install_mode", "version", "source_dir", "files")) {
+        if (-not ($manifest.PSObject.Properties.Name -contains $field)) {
+            throw "安装清单缺少字段 $field，无法使用：$Path"
+        }
+    }
+    return $manifest
 }
 
 function Copy-SkillToStage {
@@ -95,51 +343,390 @@ function Copy-SkillToStage {
     }
 }
 
-$sourcePath = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\skills\$SkillName"))
+function Get-UnmanagedFileList {
+    <# 列出目标目录里不在清单内的文件，用于卸载前的 Inspect Before Delete。 #>
+    param(
+        [Parameter(Mandatory = $true)][string]$TargetDirectory,
+        [Parameter(Mandatory = $true)]$Manifest
+    )
+
+    $known = @{}
+    foreach ($entry in $Manifest.files) {
+        $known[$entry.path] = $true
+    }
+
+    $unmanaged = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($rel in @(Get-PayloadFileList -Root $TargetDirectory)) {
+        if (-not $known.ContainsKey($rel)) {
+            $unmanaged.Add($rel)
+        }
+    }
+    return $unmanaged.ToArray()
+}
+
+# --- 公共上下文 -------------------------------------------------------------
+
+$actionCount = 0
+foreach ($switchState in @($Verify.IsPresent, $Uninstall.IsPresent, $ListTarget.IsPresent)) {
+    if ($switchState) {
+        $actionCount++
+    }
+}
+if ($actionCount -gt 1) {
+    throw "-Verify、-Uninstall 和 -ListTarget 互斥，一次只能指定一个。"
+}
+if ($script:UsePurge -and -not $Uninstall.IsPresent) {
+    throw "-Purge 只能与 -Uninstall 一起使用。"
+}
+
+if ($ListTarget.IsPresent) {
+    Show-TargetList
+    return
+}
+
+$repoRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
+$sourcePath = Join-Path (Join-Path $repoRoot "skills") $SkillName
 if (-not (Test-Path -LiteralPath (Join-Path $sourcePath "SKILL.md") -PathType Leaf)) {
     throw "找不到 Skill 源目录：$sourcePath"
 }
 
+$skillVersion = "unknown"
+$versionFile = Join-Path $repoRoot "VERSION"
+if (Test-Path -LiteralPath $versionFile -PathType Leaf) {
+    $rawVersion = (Get-Content -LiteralPath $versionFile -Raw).Trim()
+    if (-not [string]::IsNullOrWhiteSpace($rawVersion)) {
+        $skillVersion = $rawVersion
+    }
+}
+
+$sourceCommit = ""
+if (Get-Command git -ErrorAction SilentlyContinue) {
+    $gitOutput = & git -C $repoRoot rev-parse HEAD 2>$null
+    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($gitOutput)) {
+        $sourceCommit = $gitOutput.Trim()
+    }
+}
+
 $skillsRoot = Get-SkillsRoot -AgentTarget $Target -CustomDestination $Destination
 $targetPath = Join-Path $skillsRoot $SkillName
-$targetExists = Test-Path -LiteralPath $targetPath
+$manifestPath = Join-Path $skillsRoot $ManifestName
 
-if ($targetExists -and -not $Force) {
-    throw "目标已存在：$targetPath。未做任何覆盖；确认更新时请显式添加 -Force。"
+if (-not [string]::IsNullOrWhiteSpace($BackupDir)) {
+    $backupRoot = Expand-InstallPath $BackupDir
+}
+else {
+    $backupRoot = Join-Path $skillsRoot $BackupDirName
 }
 
-New-Item -ItemType Directory -Path $skillsRoot -Force | Out-Null
-$stagePath = Join-Path $skillsRoot (".{0}.install-{1}" -f $SkillName, [Guid]::NewGuid().ToString("N"))
-$backupPath = $null
-$installed = $false
+# --- 校验 -------------------------------------------------------------------
 
-try {
-    Write-Status "正在验证并暂存 Skill：$sourcePath"
-    Copy-SkillToStage -Source $sourcePath -Stage $stagePath
+function Invoke-SkillVerify {
+    if (-not (Test-Path -LiteralPath $targetPath)) {
+        throw "未检测到安装：$targetPath"
+    }
+    if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+        throw "缺少安装清单 $manifestPath，无法校验；请重新运行安装以生成清单。"
+    }
+
+    $manifest = Read-InstallManifest -Path $manifestPath
+    Write-Status "清单版本：$($manifest.version)"
+    Write-Status "安装方式：$($manifest.install_mode)"
+
+    if ($manifest.install_mode -eq "link") {
+        if (-not (Test-IsReparsePoint -Path $targetPath)) {
+            throw "清单记录为链接安装，但 $targetPath 不是链接。"
+        }
+        $actual = Get-LinkTargetPath -Path $targetPath
+        if ($actual.TrimEnd("\", "/") -ne ([string]$manifest.source_dir).TrimEnd("\", "/")) {
+            throw "链接指向 $actual，与清单记录的 $($manifest.source_dir) 不一致。"
+        }
+        Write-Status "链接指向：$actual"
+        Write-Status "校验通过：链接安装的内容随仓库变化，故跳过逐文件摘要比对。"
+        return
+    }
+
+    if (-not (Test-Path -LiteralPath $targetPath -PathType Container)) {
+        throw "清单记录为复制安装，但 $targetPath 不是目录。"
+    }
+
+    $missing = 0
+    $modified = 0
+    $checked = 0
+    foreach ($entry in $manifest.files) {
+        $checked++
+        $full = Join-Path $targetPath ($entry.path -replace '/', [IO.Path]::DirectorySeparatorChar)
+        if (-not (Test-Path -LiteralPath $full -PathType Leaf)) {
+            Write-Warning "[缺失] $($entry.path)"
+            $missing++
+            continue
+        }
+        $actualHash = (Get-FileHash -LiteralPath $full -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($actualHash -ne $entry.sha256) {
+            Write-Warning "[被修改] $($entry.path)"
+            $modified++
+        }
+    }
+
+    if ($checked -eq 0) {
+        throw "清单没有记录任何文件，内容不可信。"
+    }
+
+    $extra = @(Get-UnmanagedFileList -TargetDirectory $targetPath -Manifest $manifest)
+    foreach ($rel in $extra) {
+        Write-Warning "[清单外文件] $rel"
+    }
+
+    if ($missing -gt 0 -or $modified -gt 0 -or $extra.Count -gt 0) {
+        throw "校验失败：$checked 个受管文件中缺失 $missing、被修改 $modified，另有 $($extra.Count) 个清单外文件。"
+    }
+
+    Write-Status "校验通过：$checked 个文件的 sha256 与清单完全一致，且无清单外文件。"
+}
+
+# --- 卸载 -------------------------------------------------------------------
+
+function Invoke-SkillUninstall {
+    $targetExists = Test-Path -LiteralPath $targetPath
+    $manifestExists = Test-Path -LiteralPath $manifestPath -PathType Leaf
+
+    if (-not $targetExists -and -not $manifestExists) {
+        Write-Status "未检测到安装，无需卸载：$targetPath"
+        return
+    }
+
+    $isLink = $false
+    if ($targetExists) {
+        $isLink = Test-IsReparsePoint -Path $targetPath
+    }
+
+    if ($isLink) {
+        Write-Status "将移除链接：$targetPath"
+    }
+    elseif ($targetExists -and (Test-Path -LiteralPath $targetPath -PathType Container)) {
+        if (-not $manifestExists) {
+            if (-not $script:UseForce) {
+                throw "缺少安装清单 $manifestPath，无法确认目录归属；确认要删除 $targetPath 请添加 -Force。"
+            }
+            Write-Warning "缺少清单，按 -Force 直接删除 $targetPath。"
+        }
+        else {
+            $manifest = Read-InstallManifest -Path $manifestPath
+            $unmanaged = @(Get-UnmanagedFileList -TargetDirectory $targetPath -Manifest $manifest)
+            if ($unmanaged.Count -gt 0) {
+                foreach ($rel in $unmanaged) {
+                    Write-Warning "清单外文件（可能是本地修改）：$rel"
+                }
+                if (-not $script:UseForce) {
+                    throw "存在清单外文件，已停止；确认连同这些文件一起删除请添加 -Force。"
+                }
+                Write-Warning "按 -Force 连同上述清单外文件一起删除。"
+            }
+        }
+        Write-Status "将移除目录：$targetPath"
+    }
+    elseif ($targetExists) {
+        throw "$targetPath 既不是目录也不是链接，出于安全考虑不做删除。"
+    }
+
+    if ($manifestExists) {
+        Write-Status "将移除清单：$manifestPath"
+    }
+    $backupExists = Test-Path -LiteralPath $backupRoot -PathType Container
+    if ($backupExists) {
+        if ($script:UsePurge) {
+            Write-Status "将移除备份目录：$backupRoot"
+        }
+        else {
+            Write-Status "保留备份目录（加 -Purge 可一并删除）：$backupRoot"
+        }
+    }
+
+    if ($script:IsDryRun) {
+        Write-Status "-DryRun：以上操作均未执行。"
+        return
+    }
 
     if ($targetExists) {
-        $backupRoot = Join-Path (Split-Path $skillsRoot -Parent) "external\$SkillName\backups"
-        New-Item -ItemType Directory -Path $backupRoot -Force | Out-Null
-        $backupPath = Join-Path $backupRoot (Get-Date -Format "yyyyMMdd-HHmmssfff")
-        Move-Item -LiteralPath $targetPath -Destination $backupPath
-        Write-Status "旧版本已备份到：$backupPath"
+        if ($isLink) {
+            # 链接必须用 .NET 删除：Remove-Item -Recurse 在 5.1 上会跟随联接删掉源目录内容。
+            [IO.Directory]::Delete($targetPath)
+        }
+        else {
+            Remove-Item -LiteralPath $targetPath -Recurse -Force
+        }
+    }
+    if ($manifestExists) {
+        Remove-Item -LiteralPath $manifestPath -Force
+    }
+    if ($script:UsePurge -and $backupExists) {
+        Remove-Item -LiteralPath $backupRoot -Recurse -Force
     }
 
-    Move-Item -LiteralPath $stagePath -Destination $targetPath
-    $installed = $true
+    Write-Status "卸载完成：$targetPath"
 }
-catch {
-    if ($backupPath -and -not (Test-Path -LiteralPath $targetPath) -and (Test-Path -LiteralPath $backupPath)) {
-        Move-Item -LiteralPath $backupPath -Destination $targetPath
-        Write-Warning "安装失败，已恢复原版本：$targetPath"
+
+# --- 安装 -------------------------------------------------------------------
+
+function Test-TargetMatchesSource {
+    <# 已安装内容与源目录逐字节一致时返回 $true，让重复的 -Force 安装成为幂等空操作。 #>
+    param([Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$SourceDigest)
+
+    if (-not (Test-Path -LiteralPath $targetPath -PathType Container)) {
+        return $false
     }
-    throw
+    if (Test-IsReparsePoint -Path $targetPath) {
+        return $false
+    }
+    if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+        return $false
+    }
+
+    try {
+        $manifest = Read-InstallManifest -Path $manifestPath
+    }
+    catch {
+        return $false
+    }
+
+    if ($manifest.install_mode -ne "copy" -or $manifest.version -ne $skillVersion) {
+        return $false
+    }
+
+    try {
+        $installed = @(Get-DigestList -Root $targetPath)
+    }
+    catch {
+        return $false
+    }
+
+    if ($installed.Count -ne $SourceDigest.Count) {
+        return $false
+    }
+    for ($i = 0; $i -lt $installed.Count; $i++) {
+        if ($installed[$i] -ne $SourceDigest[$i]) {
+            return $false
+        }
+    }
+    return $true
 }
-finally {
-    if (-not $installed -and (Test-Path -LiteralPath $stagePath)) {
-        Remove-Item -LiteralPath $stagePath -Recurse -Force
+
+function New-SkillLink {
+    <# 优先建符号链接；无开发者模式/管理员权限时回落到目录联接。 #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
+    param(
+        [Parameter(Mandatory = $true)][string]$LinkPath,
+        [Parameter(Mandatory = $true)][string]$SourceDirectory
+    )
+
+    if (-not $PSCmdlet.ShouldProcess($LinkPath, "创建指向 $SourceDirectory 的链接")) {
+        return
+    }
+
+    try {
+        New-Item -ItemType SymbolicLink -Path $LinkPath -Value $SourceDirectory -ErrorAction Stop | Out-Null
+    }
+    catch {
+        Write-Warning "创建符号链接失败（$($_.Exception.Message)），改用目录联接。"
+        New-Item -ItemType Junction -Path $LinkPath -Value $SourceDirectory -ErrorAction Stop | Out-Null
     }
 }
 
-Write-Status "安装完成：$targetPath"
-Write-Status "请重启或刷新 Agent 的 Skills 列表后使用 $SkillName。"
+function Invoke-SkillInstall {
+    $sourceDigest = @(Get-DigestList -Root $sourcePath)
+    if ($sourceDigest.Count -eq 0) {
+        throw "源目录没有可安装的文件：$sourcePath"
+    }
+
+    $targetExists = Test-Path -LiteralPath $targetPath
+    if ($targetExists -and -not $script:UseForce) {
+        throw "目标已存在：$targetPath。未做任何覆盖；确认更新时请显式添加 -Force（会先备份），或用 -Verify 检查当前副本。"
+    }
+
+    if ($targetExists -and -not $script:UseLink -and (Test-TargetMatchesSource -SourceDigest $sourceDigest)) {
+        Write-Status "已安装版本 $skillVersion，且 $($sourceDigest.Count) 个文件的 sha256 全部一致，无需变更：$targetPath"
+        return
+    }
+
+    if ($script:UseLink) {
+        Write-Status "计划：在 $targetPath 创建指向 $sourcePath 的链接（开发模式）"
+    }
+    else {
+        Write-Status "计划：把 $($sourceDigest.Count) 个文件（版本 $skillVersion）安装到 $targetPath"
+    }
+    if ($targetExists) {
+        Write-Status "计划：先把现有副本备份到 $backupRoot"
+    }
+    Write-Status "计划：写出安装清单 $manifestPath"
+
+    if ($script:IsDryRun) {
+        Write-Status "-DryRun：以上操作均未执行，磁盘未被写入。"
+        return
+    }
+
+    New-Item -ItemType Directory -Path $skillsRoot -Force | Out-Null
+    $stagePath = Join-Path $skillsRoot (".{0}.install-{1}" -f $SkillName, [Guid]::NewGuid().ToString("N"))
+    $backupPath = $null
+    $installed = $false
+
+    try {
+        if (-not $script:UseLink) {
+            Write-Status "正在验证并暂存 Skill：$sourcePath"
+            Copy-SkillToStage -Source $sourcePath -Stage $stagePath
+            $stagedDigest = @(Get-DigestList -Root $stagePath)
+            if (($stagedDigest -join "`n") -ne ($sourceDigest -join "`n")) {
+                throw "暂存副本与源目录的摘要不一致，安装已停止。"
+            }
+        }
+
+        if ($targetExists) {
+            New-Item -ItemType Directory -Path $backupRoot -Force | Out-Null
+            $backupPath = Join-Path $backupRoot (Get-Date -Format "yyyyMMdd-HHmmssfff")
+            Move-Item -LiteralPath $targetPath -Destination $backupPath
+            Write-Status "旧版本已备份到：$backupPath"
+        }
+
+        if ($script:UseLink) {
+            New-SkillLink -LinkPath $targetPath -SourceDirectory $sourcePath -Confirm:$false
+            Write-InstallManifest -Path $manifestPath -Mode "link" -DigestList $sourceDigest `
+                -SourceDirectory $sourcePath -TargetDirectory $targetPath `
+                -SkillVersion $skillVersion -SourceCommit $sourceCommit
+        }
+        else {
+            Move-Item -LiteralPath $stagePath -Destination $targetPath
+            Write-InstallManifest -Path $manifestPath -Mode "copy" -DigestList $sourceDigest `
+                -SourceDirectory $sourcePath -TargetDirectory $targetPath `
+                -SkillVersion $skillVersion -SourceCommit $sourceCommit
+        }
+        $installed = $true
+    }
+    catch {
+        if ($backupPath -and -not (Test-Path -LiteralPath $targetPath) -and (Test-Path -LiteralPath $backupPath)) {
+            Move-Item -LiteralPath $backupPath -Destination $targetPath
+            Write-Warning "安装失败，已恢复原版本：$targetPath"
+        }
+        throw
+    }
+    finally {
+        if (-not $installed -and (Test-Path -LiteralPath $stagePath)) {
+            Remove-Item -LiteralPath $stagePath -Recurse -Force
+        }
+    }
+
+    Write-Status "安装完成：$targetPath"
+    Write-Status "安装清单：$manifestPath（可用 -Verify 复核，-Uninstall 卸载）"
+    Write-Status "请重启或刷新 Agent 的 Skills 列表后使用 $SkillName。"
+}
+
+if ($Verify.IsPresent) {
+    Invoke-SkillVerify
+}
+elseif ($Uninstall.IsPresent) {
+    Invoke-SkillUninstall
+}
+else {
+    Invoke-SkillInstall
+}
+
+# 显式成功退出：脚本内部调用过 git，$LASTEXITCODE 可能残留它的值。
+# 不写这一行，同进程 `& ./install.ps1` 的调用方就无法只凭退出码判断成败。
+exit 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,28 +1,81 @@
 #!/usr/bin/env bash
+# 把 computer-repair-skill 安装到某个 Agent 的 Skills 根目录。
+#
+# 设计约束：
+#   * 默认绝不覆盖已存在的安装，必须显式 --force。
+#   * 所有写入先落到同一文件系统的暂存目录，再用一次 mv 原子生效，失败自动回滚。
+#   * 安装后写出清单（含每个文件的 sha256），使 --verify 与 --uninstall 可审计。
+#   * 兼容 bash 3.2（macOS 自带版本）：不使用关联数组、mapfile、${var^^} 等新语法。
 set -euo pipefail
 
 skill_name="computer-repair-skill"
+manifest_name=".computer-repair-skill-install.json"
+backup_dir_name=".computer-repair-skill-backups"
+manifest_schema=1
+
+action="install"
 target="codex"
 destination=""
+backup_dir=""
 force=0
+dry_run=0
+link_mode=0
+purge=0
+quiet=0
+sha256_tool=""
 
-# 输出命令帮助，说明目标目录是 Skills 根目录而不是最终 Skill 目录。
+# 内置 Agent 预设。每一项的全局 Skills 目录都按官方 skills CLI 文档核对过。
+presets="codex claude claude-code cursor gemini-cli github-copilot windsurf opencode openclaw \
+agents universal antigravity augment qwen-code trae roo crush goose droid continue openhands custom"
+
 usage() {
   cat <<'EOF'
-用法: ./scripts/install.sh [选项]
+用法: ./scripts/install.sh [操作] [选项]
+
+操作（互斥，缺省为安装）:
+      --verify           校验已安装副本与清单是否一致，只读，不做任何修改
+      --uninstall        按清单移除已安装副本
+      --list-targets     列出内置 Agent 预设及其解析后的 Skills 根目录
+  -h, --help             显示帮助
 
 选项:
-  --target <codex|claude|agents|custom>  Agent 预设，默认 codex
-  --destination <path>                  覆盖预设的 Skills 根目录
-  --force                               备份现有版本后更新
-  -h, --help                            显示帮助
+      --target <preset>  Agent 预设，默认 codex；用 --list-targets 查看全部
+      --destination <p>  覆盖预设的 Skills 根目录（target 为 custom 时必填）
+      --backup-dir <p>   覆盖备份目录，默认 <skills 根目录>/.computer-repair-skill-backups
+      --link             创建指向仓库的符号链接（开发模式），不复制文件
+      --force            允许覆盖已存在的安装；覆盖前先备份
+      --purge            仅配合 --uninstall：连备份目录一起删除
+      --dry-run          只打印将要执行的操作，不写入任何文件
+      --quiet            只输出警告与错误
+
+示例:
+  ./scripts/install.sh --target claude
+  ./scripts/install.sh --target custom --destination ~/skills --force
+  ./scripts/install.sh --verify --target claude
+  ./scripts/install.sh --uninstall --target claude --purge
 EOF
 }
 
-# 统一输出错误并返回非零状态。
 fail() {
   printf '错误：%s\n' "$1" >&2
   exit 1
+}
+
+warn() {
+  printf '警告：%s\n' "$1" >&2
+}
+
+log() {
+  if ((quiet == 0)); then
+    printf '%s\n' "$1"
+  fi
+}
+
+set_action() {
+  if [[ "$action" != "install" ]]; then
+    fail "操作 --$1 与 --$action 互斥，一次只能指定一个。"
+  fi
+  action="$1"
 }
 
 while (($# > 0)); do
@@ -37,24 +90,58 @@ while (($# > 0)); do
       destination="$2"
       shift 2
       ;;
+    --backup-dir)
+      (($# >= 2)) || fail "--backup-dir 缺少参数。"
+      backup_dir="$2"
+      shift 2
+      ;;
+    --verify)
+      set_action verify
+      shift
+      ;;
+    --uninstall)
+      set_action uninstall
+      shift
+      ;;
+    --list-targets)
+      set_action list-targets
+      shift
+      ;;
+    --link)
+      link_mode=1
+      shift
+      ;;
     --force)
       force=1
       shift
       ;;
-    -h|--help)
+    --purge)
+      purge=1
+      shift
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --quiet)
+      quiet=1
+      shift
+      ;;
+    -h | --help)
       usage
       exit 0
       ;;
     *)
-      fail "未知参数：$1"
+      fail "未知参数：$1。用 --help 查看用法。"
       ;;
   esac
 done
 
-case "$target" in
-  codex|claude|agents|custom) ;;
-  *) fail "不支持的 target：$target" ;;
-esac
+if ((purge == 1)) && [[ "$action" != "uninstall" ]]; then
+  fail "--purge 只能与 --uninstall 一起使用。"
+fi
+
+# --- 路径工具 ---------------------------------------------------------------
 
 # 展开用户传入的字面量波浪号路径。
 # case 分支里的 ~ 必须加引号：不加引号时 shell 会先做波浪号展开，模式就变成 $HOME/*，
@@ -68,37 +155,375 @@ expand_user_path() {
   esac
 }
 
-# 选择各 Agent 的默认 Skills 根目录，也允许显式目录覆盖预设。
-resolve_skills_root() {
-  if [[ -n "$destination" ]]; then
-    expand_user_path "$destination"
-    return
-  fi
+# 纯字符串路径规范化：故意不调用 realpath，也不创建任何目录，
+# 这样 --dry-run 才能真正做到零副作用。
+normalize_path() (
+  path="$1"
+  case "$path" in
+    /*) ;;
+    *) path="$PWD/$path" ;;
+  esac
 
-  case "$target" in
+  set -f
+  IFS='/'
+  # 这里需要按 / 分词，因此必须不加引号；set -f 已关闭通配符展开。
+  # shellcheck disable=SC2086
+  set -- $path
+
+  out=""
+  for segment in "$@"; do
+    case "$segment" in
+      '' | '.') continue ;;
+      '..') out="${out%/*}" ;;
+      *) out="$out/$segment" ;;
+    esac
+  done
+
+  printf '%s\n' "${out:-/}"
+)
+
+config_home() {
+  printf '%s\n' "${XDG_CONFIG_HOME:-$HOME/.config}"
+}
+
+# 各 Agent 的默认全局 Skills 根目录；custom 返回空串表示必须显式给出目录。
+preset_root() {
+  case "$1" in
     codex) printf '%s/skills\n' "${CODEX_HOME:-$HOME/.codex}" ;;
-    claude) printf '%s/skills\n' "${CLAUDE_HOME:-$HOME/.claude}" ;;
+    claude | claude-code) printf '%s/skills\n' "${CLAUDE_HOME:-$HOME/.claude}" ;;
+    cursor) printf '%s/.cursor/skills\n' "$HOME" ;;
+    gemini-cli) printf '%s/.gemini/skills\n' "$HOME" ;;
+    github-copilot) printf '%s/.copilot/skills\n' "$HOME" ;;
+    windsurf) printf '%s/.codeium/windsurf/skills\n' "$HOME" ;;
+    opencode) printf '%s/opencode/skills\n' "$(config_home)" ;;
+    openclaw) printf '%s/.openclaw/skills\n' "$HOME" ;;
     agents) printf '%s/.agents/skills\n' "$HOME" ;;
-    custom) fail "target 为 custom 时必须提供 --destination。" ;;
+    universal) printf '%s/agents/skills\n' "$(config_home)" ;;
+    antigravity) printf '%s/.gemini/antigravity/skills\n' "$HOME" ;;
+    augment) printf '%s/.augment/skills\n' "$HOME" ;;
+    qwen-code) printf '%s/.qwen/skills\n' "$HOME" ;;
+    trae) printf '%s/.trae/skills\n' "$HOME" ;;
+    roo) printf '%s/.roo/skills\n' "$HOME" ;;
+    crush) printf '%s/crush/skills\n' "$(config_home)" ;;
+    goose) printf '%s/goose/skills\n' "$(config_home)" ;;
+    droid) printf '%s/.factory/skills\n' "$HOME" ;;
+    continue) printf '%s/.continue/skills\n' "$HOME" ;;
+    openhands) printf '%s/.openhands/skills\n' "$HOME" ;;
+    custom) printf '\n' ;;
+    *) return 1 ;;
   esac
 }
 
+list_targets() {
+  printf '%-16s %s\n' "预设" "全局 Skills 根目录"
+  for name in $presets; do
+    root="$(preset_root "$name")" || fail "内部错误：预设 $name 未定义。"
+    if [[ -z "$root" ]]; then
+      printf '%-16s %s\n' "$name" "（必须配合 --destination）"
+    else
+      printf '%-16s %s\n' "$name" "$(normalize_path "$(expand_user_path "$root")")"
+    fi
+  done
+  printf '\n项目级安装请改用 --destination，例如 --destination ./.claude/skills。\n'
+}
+
+resolve_skills_root() {
+  if [[ -n "$destination" ]]; then
+    normalize_path "$(expand_user_path "$destination")"
+    return
+  fi
+
+  root="$(preset_root "$target")" || fail "不支持的 target：${target}。用 --list-targets 查看全部预设。"
+  [[ -n "$root" ]] || fail "target 为 custom 时必须提供 --destination。"
+  normalize_path "$(expand_user_path "$root")"
+}
+
+# --- 摘要与清单 -------------------------------------------------------------
+
+detect_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256_tool="sha256sum"
+  elif command -v shasum >/dev/null 2>&1; then
+    sha256_tool="shasum"
+  elif command -v openssl >/dev/null 2>&1; then
+    sha256_tool="openssl"
+  else
+    fail "找不到 sha256sum、shasum 或 openssl，无法生成校验清单。"
+  fi
+}
+
+hash_file() {
+  case "$sha256_tool" in
+    sha256sum) sha256sum -- "$1" | awk '{ print $1 }' ;;
+    shasum) shasum -a 256 -- "$1" | awk '{ print $1 }' ;;
+    openssl) openssl dgst -sha256 -- "$1" | awk '{ print $NF }' ;;
+    *) fail "内部错误：未初始化摘要工具。" ;;
+  esac
+}
+
+# 列出目录下的全部普通文件（相对路径、LC_ALL=C 排序），保证清单可复现。
+list_payload_files() {
+  (
+    CDPATH='' cd -- "$1" || exit 1
+    find . -type f -print | sed 's|^\./||' | LC_ALL=C sort
+  )
+}
+
+# 生成 "相对路径 sha256" 列表。清单以空格分隔，因此这里强制校验文件名字符集。
+build_digest_list() {
+  digest_root="$1"
+  link_probe="$(find "$digest_root" -type l 2>/dev/null || true)"
+  if [[ -n "$link_probe" ]]; then
+    fail "Skill 载荷中存在符号链接，清单无法保证可复现：$digest_root"
+  fi
+
+  list_payload_files "$digest_root" | while IFS= read -r rel; do
+    [[ -n "$rel" ]] || continue
+    case "$rel" in
+      *[!A-Za-z0-9._/-]*)
+        fail "文件名含清单不支持的字符（仅允许字母、数字、点、下划线、连字符和斜杠）：$rel"
+        ;;
+    esac
+    printf '%s %s\n' "$rel" "$(hash_file "$digest_root/$rel")"
+  done
+}
+
+json_string() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+manifest_scalar() {
+  sed -n 's/^[[:space:]]*"'"$2"'": *"\([^"]*\)".*/\1/p' "$1" | head -n 1
+}
+
+# 清单里的文件条目固定一行一项，路径字符集在写入时已校验，因此可安全用 sed 解析。
+manifest_digests() {
+  sed -n 's/^[[:space:]]*{ *"path": *"\([^"]*\)", *"sha256": *"\([0-9a-f]*\)" *}.*/\1 \2/p' "$1"
+}
+
+manifest_paths_of() {
+  manifest_digests "$1" | awk '{ print $1 }'
+}
+
+write_manifest() {
+  target_manifest="$1"
+  mode="$2"
+  digest_list="$3"
+  file_count="$4"
+  tmp_manifest="$target_manifest.tmp.$$"
+
+  {
+    printf '{\n'
+    printf '  "schema": %s,\n' "$manifest_schema"
+    printf '  "skill": "%s",\n' "$(json_string "$skill_name")"
+    printf '  "version": "%s",\n' "$(json_string "$skill_version")"
+    printf '  "install_mode": "%s",\n' "$(json_string "$mode")"
+    printf '  "installed_at": "%s",\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf '  "installer": "scripts/install.sh",\n'
+    printf '  "source_dir": "%s",\n' "$(json_string "$source_dir")"
+    if [[ -n "$source_commit" ]]; then
+      printf '  "source_commit": "%s",\n' "$(json_string "$source_commit")"
+    else
+      printf '  "source_commit": null,\n'
+    fi
+    printf '  "target_path": "%s",\n' "$(json_string "$target_path")"
+    printf '  "file_count": %s,\n' "$file_count"
+    printf '  "files": [\n'
+    if ((file_count > 0)); then
+      printf '%s\n' "$digest_list" | awk '
+        { entries[NR] = sprintf("    { \"path\": \"%s\", \"sha256\": \"%s\" }", $1, $2) }
+        END {
+          for (i = 1; i <= NR; i++) {
+            printf "%s%s\n", entries[i], (i < NR ? "," : "")
+          }
+        }'
+    fi
+    printf '  ]\n'
+    printf '}\n'
+  } >"$tmp_manifest"
+
+  mv -- "$tmp_manifest" "$target_manifest"
+}
+
+# --- 公共上下文 -------------------------------------------------------------
+
 script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)"
-source_dir="$(CDPATH='' cd -- "$script_dir/../skills/$skill_name" && pwd -P)"
-[[ -f "$source_dir/SKILL.md" ]] || fail "找不到 Skill 源目录：$source_dir"
+repo_root="$(CDPATH='' cd -- "$script_dir/.." && pwd -P)"
+source_dir="$repo_root/skills/$skill_name"
 
-requested_root="$(resolve_skills_root)"
-requested_root="$(expand_user_path "$requested_root")"
-mkdir -p -- "$requested_root"
-skills_root="$(CDPATH='' cd -- "$requested_root" && pwd -P)"
-target_path="$skills_root/$skill_name"
-
-if [[ -e "$target_path" || -L "$target_path" ]]; then
-  ((force == 1)) || fail "目标已存在：$target_path。未做任何覆盖；确认更新时请显式添加 --force。"
+if [[ "$action" == "list-targets" ]]; then
+  list_targets
+  exit 0
 fi
 
-stage_path="$(mktemp -d "$skills_root/.$skill_name.install.XXXXXX")"
+[[ -f "$source_dir/SKILL.md" ]] || fail "找不到 Skill 源目录：$source_dir"
+
+skill_version="unknown"
+if [[ -f "$repo_root/VERSION" ]]; then
+  skill_version="$(tr -d ' \t\r\n' <"$repo_root/VERSION")"
+  [[ -n "$skill_version" ]] || skill_version="unknown"
+fi
+
+source_commit=""
+if command -v git >/dev/null 2>&1; then
+  source_commit="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || printf '')"
+fi
+
+skills_root="$(resolve_skills_root)"
+target_path="$skills_root/$skill_name"
+manifest_path="$skills_root/$manifest_name"
+
+if [[ -n "$backup_dir" ]]; then
+  backup_root="$(normalize_path "$(expand_user_path "$backup_dir")")"
+else
+  backup_root="$skills_root/$backup_dir_name"
+fi
+
+detect_sha256
+
+# --- 校验 -------------------------------------------------------------------
+
+run_verify() {
+  if [[ ! -e "$target_path" && ! -L "$target_path" ]]; then
+    fail "未检测到安装：$target_path"
+  fi
+  [[ -f "$manifest_path" ]] || fail "缺少安装清单 ${manifest_path}，无法校验；请重新运行安装以生成清单。"
+
+  recorded_mode="$(manifest_scalar "$manifest_path" install_mode)"
+  recorded_version="$(manifest_scalar "$manifest_path" version)"
+  recorded_source="$(manifest_scalar "$manifest_path" source_dir)"
+
+  log "清单版本：${recorded_version:-未记录}"
+  log "安装方式：${recorded_mode:-未记录}"
+
+  if [[ "$recorded_mode" == "link" ]]; then
+    [[ -L "$target_path" ]] || fail "清单记录为链接安装，但 $target_path 不是符号链接。"
+    actual_link="$(readlink "$target_path")"
+    if [[ "$actual_link" != "$recorded_source" ]]; then
+      fail "符号链接指向 ${actual_link}，与清单记录的 $recorded_source 不一致。"
+    fi
+    log "链接指向：$actual_link"
+    log "校验通过：链接安装的内容随仓库变化，故跳过逐文件摘要比对。"
+    return 0
+  fi
+
+  [[ -d "$target_path" ]] || fail "清单记录为复制安装，但 $target_path 不是目录。"
+
+  missing=0
+  modified=0
+  checked=0
+  while read -r rel expected; do
+    [[ -n "$rel" ]] || continue
+    checked=$((checked + 1))
+    if [[ ! -f "$target_path/$rel" ]]; then
+      printf '  [缺失] %s\n' "$rel" >&2
+      missing=$((missing + 1))
+      continue
+    fi
+    if [[ "$(hash_file "$target_path/$rel")" != "$expected" ]]; then
+      printf '  [被修改] %s\n' "$rel" >&2
+      modified=$((modified + 1))
+    fi
+  done <<EOF
+$(manifest_digests "$manifest_path")
+EOF
+
+  ((checked > 0)) || fail "清单没有记录任何文件，内容不可信。"
+
+  extra=0
+  known_paths="$(manifest_paths_of "$manifest_path")"
+  while IFS= read -r rel; do
+    [[ -n "$rel" ]] || continue
+    if ! printf '%s\n' "$known_paths" | grep -Fxq -- "$rel"; then
+      printf '  [清单外文件] %s\n' "$rel" >&2
+      extra=$((extra + 1))
+    fi
+  done <<EOF
+$(list_payload_files "$target_path")
+EOF
+
+  if ((missing > 0 || modified > 0 || extra > 0)); then
+    fail "校验失败：$checked 个受管文件中缺失 ${missing}、被修改 ${modified}，另有 $extra 个清单外文件。"
+  fi
+
+  log "校验通过：$checked 个文件的 sha256 与清单完全一致，且无清单外文件。"
+}
+
+# --- 卸载 -------------------------------------------------------------------
+
+list_unmanaged_files() {
+  known_paths="$(manifest_paths_of "$manifest_path")"
+  while IFS= read -r rel; do
+    [[ -n "$rel" ]] || continue
+    if ! printf '%s\n' "$known_paths" | grep -Fxq -- "$rel"; then
+      printf '  %s\n' "$rel"
+    fi
+  done <<EOF
+$(list_payload_files "$target_path")
+EOF
+}
+
+run_uninstall() {
+  if [[ ! -e "$target_path" && ! -L "$target_path" && ! -f "$manifest_path" ]]; then
+    log "未检测到安装，无需卸载：$target_path"
+    return 0
+  fi
+
+  if [[ -L "$target_path" ]]; then
+    log "将移除符号链接：$target_path"
+  elif [[ -d "$target_path" ]]; then
+    if [[ ! -f "$manifest_path" ]]; then
+      ((force == 1)) || fail "缺少安装清单 ${manifest_path}，无法确认目录归属；确认要删除 $target_path 请添加 --force。"
+      warn "缺少清单，按 --force 直接删除 ${target_path}。"
+    else
+      unmanaged="$(list_unmanaged_files)"
+      if [[ -n "$unmanaged" ]]; then
+        printf '以下文件不在安装清单中（可能是本地修改）：\n%s\n' "$unmanaged" >&2
+        ((force == 1)) || fail "存在清单外文件，已停止；确认连同这些文件一起删除请添加 --force。"
+        warn "按 --force 连同上述清单外文件一起删除。"
+      fi
+    fi
+    log "将移除目录：$target_path"
+  elif [[ -e "$target_path" ]]; then
+    fail "$target_path 既不是目录也不是符号链接，出于安全考虑不做删除。"
+  fi
+
+  if [[ -f "$manifest_path" ]]; then
+    log "将移除清单：$manifest_path"
+  fi
+  if [[ -d "$backup_root" ]]; then
+    if ((purge == 1)); then
+      log "将移除备份目录：$backup_root"
+    else
+      log "保留备份目录（加 --purge 可一并删除）：$backup_root"
+    fi
+  fi
+
+  if ((dry_run == 1)); then
+    log "--dry-run：以上操作均未执行。"
+    return 0
+  fi
+
+  if [[ -L "$target_path" ]]; then
+    rm -f -- "$target_path"
+  elif [[ -d "$target_path" ]]; then
+    rm -rf -- "$target_path"
+  fi
+  if [[ -f "$manifest_path" ]]; then
+    rm -f -- "$manifest_path"
+  fi
+  if ((purge == 1)) && [[ -d "$backup_root" ]]; then
+    rm -rf -- "$backup_root"
+  fi
+
+  log "卸载完成：$target_path"
+}
+
+# --- 安装 -------------------------------------------------------------------
+
+stage_path=""
 backup_path=""
+source_digests=""
 
 # 异常退出时只清理本次创建的临时目录，并在需要时恢复原版本。
 on_exit() {
@@ -116,23 +541,90 @@ on_exit() {
 
   exit "$status"
 }
-trap on_exit EXIT
 
-printf '正在验证并暂存 Skill：%s\n' "$source_dir"
-cp -R -- "$source_dir"/. "$stage_path"/
-[[ -f "$stage_path/SKILL.md" ]] || fail "暂存副本缺少 SKILL.md，安装已停止。"
+# 已安装内容与源目录逐字节一致时返回 0，让重复的 --force 安装成为幂等空操作。
+target_matches_source() {
+  [[ -d "$target_path" && ! -L "$target_path" ]] || return 1
+  [[ -f "$manifest_path" ]] || return 1
+  [[ "$(manifest_scalar "$manifest_path" install_mode)" == "copy" ]] || return 1
+  [[ "$(manifest_scalar "$manifest_path" version)" == "$skill_version" ]] || return 1
 
-if [[ -e "$target_path" || -L "$target_path" ]]; then
-  backup_root="$(dirname -- "$skills_root")/external/$skill_name/backups"
-  mkdir -p -- "$backup_root"
-  backup_path="$backup_root/$(date '+%Y%m%d-%H%M%S')-$$"
-  mv -- "$target_path" "$backup_path"
-  printf '旧版本已备份到：%s\n' "$backup_path"
-fi
+  installed_digests="$(build_digest_list "$target_path" 2>/dev/null || true)"
+  [[ -n "$installed_digests" && "$installed_digests" == "$source_digests" ]]
+}
 
-mv -- "$stage_path" "$target_path"
-stage_path=""
-trap - EXIT
+run_install() {
+  source_digests="$(build_digest_list "$source_dir")"
+  source_count="$(printf '%s\n' "$source_digests" | grep -c . || true)"
+  ((source_count > 0)) || fail "源目录没有可安装的文件：$source_dir"
 
-printf '安装完成：%s\n' "$target_path"
-printf '请重启或刷新 Agent 的 Skills 列表后使用 %s。\n' "$skill_name"
+  target_exists=0
+  if [[ -e "$target_path" || -L "$target_path" ]]; then
+    target_exists=1
+  fi
+
+  if ((target_exists == 1)) && ((force == 0)); then
+    fail "目标已存在：${target_path}。未做任何覆盖；确认更新时请显式添加 --force（会先备份），或用 --verify 检查当前副本。"
+  fi
+
+  if ((target_exists == 1)) && ((link_mode == 0)) && target_matches_source; then
+    log "已安装版本 ${skill_version}，且 $source_count 个文件的 sha256 全部一致，无需变更：$target_path"
+    return 0
+  fi
+
+  if ((link_mode == 1)); then
+    log "计划：在 $target_path 创建指向 $source_dir 的符号链接（开发模式）"
+  else
+    log "计划：把 $source_count 个文件（版本 ${skill_version}）安装到 $target_path"
+  fi
+  if ((target_exists == 1)); then
+    log "计划：先把现有副本备份到 $backup_root"
+  fi
+  log "计划：写出安装清单 $manifest_path"
+
+  if ((dry_run == 1)); then
+    log "--dry-run：以上操作均未执行，磁盘未被写入。"
+    return 0
+  fi
+
+  mkdir -p -- "$skills_root"
+  trap on_exit EXIT
+
+  if ((link_mode == 0)); then
+    stage_path="$(mktemp -d "$skills_root/.$skill_name.install.XXXXXX")"
+    log "正在验证并暂存 Skill：$source_dir"
+    cp -R -- "$source_dir"/. "$stage_path"/
+    [[ -f "$stage_path/SKILL.md" ]] || fail "暂存副本缺少 SKILL.md，安装已停止。"
+    staged_digests="$(build_digest_list "$stage_path")"
+    [[ "$staged_digests" == "$source_digests" ]] || fail "暂存副本与源目录的摘要不一致，安装已停止。"
+  fi
+
+  if ((target_exists == 1)); then
+    mkdir -p -- "$backup_root"
+    backup_path="$backup_root/$(date '+%Y%m%d-%H%M%S')-$$"
+    mv -- "$target_path" "$backup_path"
+    log "旧版本已备份到：$backup_path"
+  fi
+
+  if ((link_mode == 1)); then
+    ln -s -- "$source_dir" "$target_path"
+    write_manifest "$manifest_path" "link" "$source_digests" "$source_count"
+  else
+    mv -- "$stage_path" "$target_path"
+    stage_path=""
+    write_manifest "$manifest_path" "copy" "$source_digests" "$source_count"
+  fi
+
+  trap - EXIT
+
+  log "安装完成：$target_path"
+  log "安装清单：${manifest_path}（可用 --verify 复核，--uninstall 卸载）"
+  log "请重启或刷新 Agent 的 Skills 列表后使用 ${skill_name}。"
+}
+
+case "$action" in
+  install) run_install ;;
+  verify) run_verify ;;
+  uninstall) run_uninstall ;;
+  *) fail "内部错误：未处理的操作 $action" ;;
+esac

--- a/tests/check_portability.py
+++ b/tests/check_portability.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""跨平台可移植性静态守卫。
+
+前三条规则对应三个真实故障：都只在 CI 的非 Linux 机器上才会炸，在 Linux 上本地
+跑一万遍也复现不出来，所以只能靠静态检查在 lint 阶段拦住。第四条是同一类问题在
+PowerShell 侧的镜像，目前零违规，纯粹用来防止以后写回来。
+
+1. macOS 自带的 Bash 是 3.2.57（Apple 因为 GPLv3 不再跟进新版本）。它判断
+   变量名合法字符用的是 C 库的 `isalnum()`，而 BSD libc 在 UTF-8 locale 下
+   会把 0x80-0xFF 当成 Latin-1 字母返回真。于是 `"版本 $skill_version（旧）"`
+   里的变量名被解析成 `skill_version\\xef`，在 `set -u` 下直接以
+   `skill_version\\xef: unbound variable` 退出。glibc 不会这样，所以同一份
+   脚本在 Ubuntu 上完全正常。
+   规则：Shell 脚本和工作流的 bash 步骤里，`$var` 后面紧跟非 ASCII 字符时
+   必须写成 `${var}`。
+
+2. GitHub Actions 会把 `shell: powershell` 步骤的 run 块写成**不带 BOM** 的
+   临时 `.ps1`，Windows PowerShell 5.1 按系统 ANSI 代码页（en-US 镜像是
+   CP1252）解码它。CP1252 把 0x91-0x94 映射成 `‘ ’ “ ”`，而 PowerShell 把这些
+   排版引号当作字符串定界符 —— 例如「错」的 UTF-8 是 E9 94 99，中间的 0x94
+   会变成右双引号，字符串提前闭合，整个脚本解析失败。
+   规则：`shell: powershell` 的 run 块必须是纯 ASCII；需要中文断言就另起一个
+   `shell: pwsh` 步骤（PowerShell 7 按 UTF-8 读临时脚本，不受影响）。
+
+3. `Path.write_text()` 在 Windows 上默认做行尾翻译，把 `\\n` 写成 `\\r\\n`。
+   测试与登记生成器写出的 `.md` 会立刻违反 `.gitattributes` 的 LF 约束，
+   校验器随即报「含 CRLF 行尾」。
+   规则：`tests/` 下的 `write_text()` 必须显式传 `newline="\\n"`。
+
+4. PowerShell 的裸变量引用 `$name` 会一直吞掉 Unicode 字母（L*）、十进制数字（Nd）
+   和组合记号（Mn）；实测 `"$name的"` 展开成空串，而 `Set-StrictMode -Version Latest`
+   下直接抛 `The variable '$name的' cannot be retrieved`。全角标点（。：（）—）和空格
+   会终止变量名，所以本仓库现有的中文消息恰好都安全 —— 但这完全是运气。
+   规则：`.ps1` 与 `shell: pwsh` 的 run 块里，`$var` 紧跟非 ASCII 字母/数字/组合记号时
+   必须写成 `${var}`。
+
+用法：python tests/check_portability.py [仓库根目录]
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+import unicodedata
+from pathlib import Path
+
+VAR_BEFORE_NON_ASCII = re.compile(r"\$([A-Za-z_][A-Za-z0-9_]*)(?=[^\x00-\x7f])")
+# PowerShell 允许 `$scope:name` 形式，所以名字部分要接受一个可选的作用域限定符。
+PS_VAR_BEFORE_NON_ASCII = re.compile(r"\$([A-Za-z_][A-Za-z0-9_]*(?::[A-Za-z_][A-Za-z0-9_]*)?)([^\x00-\x7f])")
+# PowerShell 判定「还算变量名」的 Unicode 类别，实测得出。
+PS_NAME_CATEGORIES = ("Lu", "Ll", "Lt", "Lm", "Lo", "Nd", "Mn")
+STEP_START = re.compile(r"^(?P<indent>[ ]*)-[ ]+name:")
+BASH_SHELLS = {"", "bash", "sh"}
+POWERSHELL_SHELLS = {"powershell"}
+PWSH_SHELLS = {"pwsh"}
+
+
+def iter_steps(lines: list[str]) -> list[tuple[int, int, int]]:
+    """切出工作流里的每个步骤，返回 (起始行下标, 结束行下标, 短横线缩进)。"""
+    steps: list[tuple[int, int, int]] = []
+    index = 0
+    while index < len(lines):
+        match = STEP_START.match(lines[index])
+        if match is None:
+            index += 1
+            continue
+        dash_indent = len(match.group("indent"))
+        end = index + 1
+        while end < len(lines):
+            line = lines[end]
+            if line.strip() and len(line) - len(line.lstrip()) <= dash_indent:
+                break
+            end += 1
+        steps.append((index, end, dash_indent))
+        index = end
+    return steps
+
+
+def step_shell_and_run(
+    lines: list[str], start: int, end: int, dash_indent: int
+) -> tuple[str, int, list[str]]:
+    """取出一个步骤声明的 shell 与 run 块正文。没有 run 块时返回空正文。"""
+    key_indent = dash_indent + 2
+    shell = ""
+    run_line = -1
+    for index in range(start, end):
+        line = lines[index]
+        if not line.strip() or len(line) - len(line.lstrip()) != key_indent:
+            continue
+        stripped = line.strip()
+        if stripped.startswith("shell:"):
+            shell = stripped.split(":", 1)[1].strip().strip("\"'")
+        elif stripped.startswith("run:"):
+            run_line = index
+    if run_line < 0:
+        return shell, -1, []
+    body: list[str] = []
+    for index in range(run_line + 1, end):
+        line = lines[index]
+        if line.strip() and len(line) - len(line.lstrip()) <= key_indent:
+            break
+        body.append(line)
+    return shell, run_line, body
+
+
+def check_braced_variables(path: Path, text: str, offset: int = 0) -> list[str]:
+    """规则 1：变量引用紧跟非 ASCII 字符时必须带花括号。"""
+    problems = []
+    for number, line in enumerate(text.splitlines(), start=1 + offset):
+        for match in VAR_BEFORE_NON_ASCII.finditer(line):
+            name = match.group(1)
+            problems.append(
+                f"{path}:{number}: `${name}` 后面紧跟非 ASCII 字符，"
+                f"macOS 的 Bash 3.2 会把它并进变量名；请写成 `${{{name}}}`。\n"
+                f"    {line.strip()}"
+            )
+    return problems
+
+
+def check_ascii_only(path: Path, lines: list[str], first_line: int) -> list[str]:
+    """规则 2：Windows PowerShell 5.1 步骤的 run 块必须是纯 ASCII。"""
+    problems = []
+    for offset, line in enumerate(lines):
+        bad = [char for char in line if ord(char) > 127]
+        if not bad:
+            continue
+        problems.append(
+            f"{path}:{first_line + offset}: `shell: powershell` 的 run 块出现非 ASCII 字符 "
+            f"{''.join(sorted(set(bad)))}；Windows PowerShell 5.1 会按 ANSI 代码页解码这段临时脚本，"
+            f"中文里的 0x91-0x94 字节会变成排版引号并提前闭合字符串。"
+            f"请把这段断言挪到 `shell: pwsh` 步骤。\n    {line.strip()}"
+        )
+    return problems
+
+
+def check_powershell_braced_variables(path: Path, text: str, offset: int = 0) -> list[str]:
+    """规则 4：PowerShell 裸变量名会吞掉 Unicode 字母/数字/组合记号。"""
+    problems = []
+    for number, line in enumerate(text.splitlines(), start=1 + offset):
+        for match in PS_VAR_BEFORE_NON_ASCII.finditer(line):
+            name, following = match.group(1), match.group(2)
+            category = unicodedata.category(following)
+            if category not in PS_NAME_CATEGORIES:
+                continue
+            problems.append(
+                f"{path}:{number}: `${name}` 后面紧跟 {following!r}（Unicode 类别 {category}），"
+                f"PowerShell 会把它并进变量名；`Set-StrictMode -Version Latest` 下会抛"
+                f"「cannot be retrieved」。请写成 `${{{name}}}`。\n    {line.strip()}"
+            )
+    return problems
+
+
+def check_write_text_newline(path: Path, text: str) -> list[str]:
+    """规则 3：write_text() 必须显式指定 LF，否则 Windows 会写出 CRLF。"""
+    problems = []
+    for node in ast.walk(ast.parse(text)):
+        if not isinstance(node, ast.Call):
+            continue
+        function = node.func
+        if not isinstance(function, ast.Attribute) or function.attr != "write_text":
+            continue
+        if any(keyword.arg == "newline" for keyword in node.keywords):
+            continue
+        problems.append(
+            f"{path}:{node.lineno}: write_text() 没有显式 newline；Windows 上会把 \\n 写成 \\r\\n，"
+            f'违反 .gitattributes 的 LF 约束。请加 newline="\\n"。'
+        )
+    return problems
+
+
+def main() -> int:
+    root = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else Path(__file__).resolve().parent.parent
+    problems: list[str] = []
+    checked = 0
+
+    for script in sorted((root / "scripts").glob("*.sh")):
+        checked += 1
+        problems += check_braced_variables(script.relative_to(root), script.read_text(encoding="utf-8"))
+
+    for script in sorted((root / "scripts").glob("*.ps1")):
+        checked += 1
+        # 这两个脚本带 UTF-8 BOM，用 utf-8-sig 读，否则 BOM 会进第一行。
+        problems += check_powershell_braced_variables(
+            script.relative_to(root), script.read_text(encoding="utf-8-sig")
+        )
+
+    workflows = sorted((root / ".github" / "workflows").glob("*.yml"))
+    for workflow in workflows:
+        checked += 1
+        relative = workflow.relative_to(root)
+        lines = workflow.read_text(encoding="utf-8").splitlines()
+        for start, end, dash_indent in iter_steps(lines):
+            shell, run_line, body = step_shell_and_run(lines, start, end, dash_indent)
+            if run_line < 0:
+                continue
+            if shell in BASH_SHELLS:
+                problems += check_braced_variables(relative, "\n".join(body), offset=run_line + 1)
+            elif shell in POWERSHELL_SHELLS:
+                problems += check_ascii_only(relative, body, run_line + 2)
+            elif shell in PWSH_SHELLS:
+                problems += check_powershell_braced_variables(relative, "\n".join(body), offset=run_line + 1)
+
+    for module in sorted((root / "tests").glob("*.py")):
+        checked += 1
+        problems += check_write_text_newline(module.relative_to(root), module.read_text(encoding="utf-8"))
+
+    if problems:
+        for problem in problems:
+            print(f"[error] {problem}", file=sys.stderr)
+        print(
+            f"\n可移植性检查失败：{len(problems)} 项问题（已检查 {checked} 个文件）。",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"可移植性检查通过：{checked} 个文件，4 条规则全部满足。")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
堆叠 PR 第 4/6 层 · base `stage-c/ci-and-lint-hardening` · 3 commits · 8 files, +2990 / −119

给安装器补上完整生命周期（可校验、可卸载、可预演），并新增只读证据采集脚本。

## 安装器改造（`97eb8b6`）

### 新增开关

| Bash | PowerShell | 作用 |
|---|---|---|
| `--verify` | `-Verify` | 按清单里的 sha256 逐个校验已安装文件，检出改动与缺失 |
| `--uninstall` / `--purge` | `-Uninstall` / `-Purge` | 只删除清单登记过的文件；`--purge` 一并清掉备份目录 |
| `--list-targets` | `-ListTarget` | 列出预设 Agent 与解析后的目标路径 |
| `--link` | `-Link` | 符号链接安装（开发用），而非复制 |
| `--dry-run` | `-DryRun` | 打印计划、零副作用 |
| `--backup-dir` | `-BackupDir` | 自定义备份目录 |
| `--quiet` | `-Quiet` | 抑制进度输出 |

### 安装清单

新增 `<Skills 根目录>/.computer-repair-skill-install.json`（`schema: 1`），记录版本、来源目录、来源 commit、安装方式与每个文件的 sha256。

- `--verify` 靠它检出篡改。
- `--uninstall` 靠它确认目录归属，**不会误删用户自己放进去的文件**——遇到清单外文件先列出并要求 `--force`。
- 两个安装器写出的清单逐行同构：PowerShell 装的副本能用 `install.sh --verify` 复核。

### 错误输出与退出码

`install.ps1` 有 22 处 `throw` 且 `$ErrorActionPreference = "Stop"`，但主入口分派此前没有顶层保护。结果是"尚未安装就 `-Verify`"这类**预期内**的错误会给用户抛一整段 PowerShell 异常堆栈：

```text
Exception: /path/scripts/install.ps1:412
Line |
 412 |          throw "未检测到安装：$targetPath"
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

而 `install.sh` 的 `fail()` 只输出干净的一行。退出码两侧本来就是对的（都是 1），是纯 UX 缺口。

现在加**脚本作用域 `trap`**（不是末尾包一个 `try/catch`——参数校验散落在函数定义之间的主体代码里，单个 `try` 块包不住），把消息收敛成单行写 stderr 并 `exit 1`；主入口分派之后显式 `exit 0`。后者是因为脚本内部调用过 `git`，不显式退出时 `$LASTEXITCODE` 会残留 git 的值，让调用方误判失败。

`trap` 不影响函数内已有的 `try/finally` 回滚——异常向外传播时 `finally` 先执行，`trap` 才拿到控制权，暂存目录仍会被清理。

对齐后的实测输出：

| 场景 | `install.sh` | `install.ps1` | rc |
|---|---|---|---|
| 未安装时 `--verify` | `错误：未检测到安装：<path>` | `错误：未检测到安装：<path>` | 1 / 1 |
| `--purge` 单独使用 | `错误：--purge 只能与 --uninstall 一起使用。` | `错误：-Purge 只能与 -Uninstall 一起使用。` | 1 / 1 |
| 未安装时 `--uninstall` | `未检测到安装，无需卸载：<path>` | 同左 | 0 / 0（幂等） |

唯一剩下的差异是"未知参数"：bash 侧是自己解析的，PowerShell 侧由参数绑定器报英文，属框架行为。

### 预设 Agent 目标

从 3 个扩到 21 个，覆盖 Claude Code、Codex、Cursor、Gemini CLI、GitHub Copilot、Windsurf、OpenCode、OpenClaw、Antigravity、Augment、Qwen Code、Trae、Roo Code、Crush、Goose、Droid、Continue、OpenHands 等，另有 `custom` 走 `--destination`。目录映射逐条对照上游 Skills CLI 的官方支持列表核实；`opencode`/`universal`/`crush`/`goose` 走 `${XDG_CONFIG_HOME:-$HOME/.config}`。

## 只读采集脚本（`194a8ab`）

新增 `scripts/collect-health.sh` 与 `scripts/collect-health.ps1`。11 个小节，输出结构化 JSON 或 Markdown，支持 `--sections` / `--timeout` / `--output` / `--no-identity`。

边界是明确的：**严格只查不改、不联网、除 `--output` 外不写任何路径**，输出逐行过滤疑似凭据，`--no-identity` 进一步去掉主机名、用户名、序列号。设计目的是让用户能把设备事实一次性交给 Agent，而不是让 Agent 反复试探性执行命令。

## 三平台端到端测试（`bced143`）

新增 `installer` 与 `collector` 两个 job，在 ubuntu / windows / macos 上真实执行。安装器跑完整序列：dry-run 零副作用 → 首装 → 清单校验 → 拒绝覆盖 → 篡改检出 → `--force` 备份 → 幂等 → 清单外文件拦截 → 卸载无残留 → 链接模式。采集脚本三平台执行并断言输出合法；Windows 侧额外用 Windows PowerShell 5.1 再跑一遍。

两个 job 最后都断言 `git status --porcelain` 为空——这是"脚本只写目标目录"的可执行证据，而不是文档承诺。

写 Windows 侧断言时有个坑值得记下来：同进程 `& ./install.ps1` 调用时，子脚本里的 `exit 1` **不是异常**，调用方的 `catch` 不会触发。只靠"有没有抛异常"判断失败会全部漏掉。所以 `Invoke-Installer` 改为调用前 `$global:LASTEXITCODE = 0`、调用后按退出码 `throw`，`Assert-InstallerFails` 再用 `try/catch` 同时覆盖两种失败形态。`$LASTEXITCODE` 有粘性——脚本不显式 exit 时会保留上一次的值，所以两端都要堵：安装器显式 exit，CI 侧调用前清零。

## CI 实跑抓到的跨平台问题

本层新增的三平台端到端测试是这轮最有价值的产出：**它抓到了 3 个本地 Linux 上无法复现的
真实 bug**，其中 1 个存在于已发布的 v1.1.0。

### 1. macOS 自带的 Bash 3.2 会把中文首字节吃进变量名

```text
./scripts/install.sh: line 578: skill_version�: unbound variable
./scripts/collect-health.sh: line 462: title�: unbound variable
```

Apple 因为 GPLv3 停在 bash 3.2.57。它判断变量名合法字符用的是 C 库 `isalnum()`，而
BSD libc 在 UTF-8 locale 下把 0x80–0xFF 当 Latin-1 字母返回真。于是
`log "计划：把 $source_count 个文件（版本 $skill_version）安装到 $target_path"` 里的
`$skill_version` 被解析成 `skill_version` 再加上 `）`（U+FF09 = `EF BC 89`）的首字节 0xEF，
`set -u` 下直接以 `unbound variable` 退出——用户看不到那句中文提示，只看到一串乱码报错。
glibc 不这么干，所以同一份脚本在 Ubuntu 上完全正常。

本层把 `install.sh` 12 处、`collect-health.sh` 7 处改写成 `${var}`。花括号无条件终止
变量名扫描，与 libc 无关。

两点说明：

- **只在必要处加花括号**，所以同一个字符串里会出现 `${missing}` 与 `$checked` 混用
  （`$checked` 后面跟的是空格，安全）。这是刻意的最小 diff——全文无条件加花括号会把
  几百行无关代码卷进来，反而看不清哪一处是真的有风险。
- **位置参数 `$1` 不受影响**，所以 `fail "未知参数：$1。"` 这类写法保留原样。bash 对
  不带花括号的位置参数只读一个字符，从不进入变量名扫描循环；实测 `$1abc` → `fooabc`、
  `$12` → `foo2`，与 libc 无关。

`install.sh` 里有 1 处（`目标已存在：$target_path。`）是 v1.1.0 就有的：macOS 用户重复
安装时看到的不是"目标已存在，请加 --force"，而是 `target_path<0xE3>: unbound variable`（`。` 是 U+3002 = `E3 80 82`）。
这一处记在 CHANGELOG 的 Fixed 下。其余 11 处在本层新增的代码里。

### 2. Windows PowerShell 5.1 按 ANSI 解码 Actions 生成的临时脚本

```text
Unexpected token '™è¯¯ï¼ˆ5.1' in expression or statement.
Unexpected token '¶å†™å‡ºäº†ä¸»æœºæ' in expression or statement.
Missing closing '}' in statement block or type definition.
```

Actions 把 `shell: powershell` 的 run 块写成**不带 BOM** 的临时 `.ps1`，5.1 按 CP1252
解码。本层这个步骤的 run 块有 74 个非 ASCII 字符，其中 4 个字节落进 CP1252 的双引号类
（0x84/0x93/0x94 → `„ “ ”`；实测三者都会终止 PowerShell 的双引号串）。第一个致命的是
`错`：UTF-8 是 E9 **94** 99，0x94 解成 `”` 把 `throw "Markdown 标题缺失或编码错误（…）"`
提前闭合。报错里那个 `'™è¯¯ï¼ˆ5.1'` 就是剩下的字节 `99 误（5.1` 被逐字节按 CP1252 解出来
的样子。第二条报错同理：`throw "-NoIdentity 仍然写出了主机标识行"` 里 `然` 是 E7 **84** B6，
0x84 解成 `„` 闭合，残余 `B6 写出了主机标…` 按 CP1252 就是 `¶å†™å‡ºäº†ä¸»æœºæ`。
两条报错都能对到字节，根因没有猜测成分。

修法不是转义（5.1 不支持 `` `u{XXXX} ``，只能用 `[char]0x8BA1` 拼中文针，可读性太差），
而是**拆步骤**：`shell: powershell` 步骤改成纯 ASCII，只负责"用 5.1 跑一遍并确认产出了
报告"；中文断言挪到紧随其后的 `shell: pwsh` 步骤，读 5.1 刚写出的同一份
`$env:RUNNER_TEMP/health-51.md`。PowerShell 7 按 UTF-8 读临时脚本，中文针可以照写。
断言强度不变，只是执行位置换了。

### 3. Windows 上 `Path.write_text()` 写出 CRLF

`newline` 默认 `None` 会做行尾翻译，测试写进临时仓库的 Playbook 变成 CRLF，随即被
`.gitattributes` 的 LF 约束判失败（6 个用例）。修复在 B 层，本层随分支带上。

### 静态守卫：`tests/check_portability.py`

三个 bug 的共同点是**只在特定 runner 上出现，Linux 上零信号**。靠"下次记得"防不住，
所以新增一个零依赖静态检查，接进 lint job（`python tests/check_portability.py`），4 条规则：

| # | 范围 | 规则 |
|---|---|---|
| 1 | `scripts/*.sh` + 工作流 bash 步骤 | `$var` 紧跟非 ASCII 时必须写 `${var}` |
| 2 | `shell: powershell` 的 run 块 | 必须纯 ASCII |
| 3 | `tests/*.py` 的 `write_text()` | 必须显式 `newline=` |
| 4 | `scripts/*.ps1` + `shell: pwsh` 的 run 块 | `$var` 紧跟 Unicode 字母/数字/组合记号时必须写 `${var}` |

规则 3 用 `ast` 遍历而不是正则——正则会把守卫脚本自己 docstring 里的 `write_text()`
误报成违规。

规则 4 是顺手补的**预防性**规则，目前零违规。PowerShell 的裸变量引用会一直吞掉 Unicode
字母（L\*）、十进制数字（Nd）和组合记号（Mn）：实测 `"$name的"` 展开成空串，
`Set-StrictMode -Version Latest` 下直接抛 `The variable '$name的' cannot be retrieved`。
两个 `.ps1` 都开了 `Set-StrictMode -Version Latest`，而全部用户可见消息都是中文——现有
写法之所以安全，纯粹是因为全角标点（`。：（）—`）和空格属于终止变量名的类别。这条规则
把"恰好安全"变成"保证安全"。

守卫本身也验过：把它放到修复前的树上跑报 42 项问题，分布为
`tests/test_validate_skill.py` 14、`scripts/install.sh` 12、
`.github/workflows/validate.yml` 8、`scripts/collect-health.sh` 7、
`tests/playbook_registry.py` 1——正好覆盖上面三个 bug 的全部命中点；另外注入 5 处人造
违规（4 条规则各至少一处）后逐条命中且行号准确；修复后的树上 10 个文件 0 违规。
