### PR TITLE
ci(release): version 变化后自动打 tag 并发布 Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release
+
+# SKILL.md 的 version 变化后自动打 tag 并发布，说明正文从 CHANGELOG 摘录。
+# 只在版本或变更记录改动时触发；tag 已存在就跳过，所以重复触发是安全的。
+on:
+  push:
+    branches: [main]
+    paths:
+      - "skills/computer-repair-skill/SKILL.md"
+      - "CHANGELOG.md"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Tag and publish
+    runs-on: ubuntu-latest
+    env:
+      PYTHONUTF8: "1"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          # 需要完整历史与已有 tag，才能判断该版本是否已发布。
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Resolve version
+        id: version
+        shell: bash
+        run: |
+          version="$(python tools/release_notes.py --print-version)"
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+          if git ls-remote --exit-code --tags origin "refs/tags/v$version" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "v$version 已发布，跳过。"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "准备发布 v$version。"
+          fi
+
+      - name: Validate before releasing
+        if: steps.version.outputs.exists == 'false'
+        shell: bash
+        run: |
+          python tools/extract_data.py --check
+          python tests/validate_skill.py
+
+      - name: Build release notes
+        if: steps.version.outputs.exists == 'false'
+        shell: bash
+        run: python tools/release_notes.py --output "$RUNNER_TEMP/release-notes.md"
+
+      - name: Create annotated tag
+        if: steps.version.outputs.exists == 'false'
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$VERSION" -m "$VERSION"
+          git push origin "refs/tags/v$VERSION"
+
+      - name: Publish GitHub Release
+        if: steps.version.outputs.exists == 'false'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
+            --notes-file "$RUNNER_TEMP/release-notes.md" \
+            --verify-tag \
+            --latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 `skills/computer-repair-skill/agents/openai.yaml` 里，`tests/validate_skill.py`
 会校验两者一致并要求本文件存在对应条目。1.1.0 之前的变更请查阅 Git 历史。
 
+## [Unreleased]
+
+### Added
+
+- 新增 `Release` 工作流与 `tools/release_notes.py`：`SKILL.md` 的 `version` 变化并合入
+  `main` 后自动打 annotated tag 并发布 GitHub Release，说明正文从本文件对应版本条目摘录。
+  发布前会先跑 `tools/extract_data.py --check` 与 `tests/validate_skill.py`，任一失败就不发布；
+  对应 tag 已存在时跳过，因此重复触发是安全的。
+
 ## [1.2.0] - 2026-09-09
 
 本次发布补齐 macOS 与 Linux 的应用清理能力，复核并同步了 `NOTICE` 记录的全部上游项目，

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,4 +79,21 @@ python scripts/sync_docs_table.py
 ./scripts/install.sh --target custom --destination "$(mktemp -d)/skills"
 ```
 
+## 发布版本
+
+版本号写在 `skills/computer-repair-skill/SKILL.md` 与 `skills/computer-repair-skill/agents/openai.yaml`，
+两处必须一致，且 `CHANGELOG.md` 要有对应的 `## [x.y.z] - YYYY-MM-DD` 条目——校验器会检查这三点。
+
+具备这些之后不需要手工打 tag：改动合入 `main` 后，`Release` 工作流会自动创建
+`v<version>` annotated tag 并发布 GitHub Release，说明正文取自 `CHANGELOG.md` 的该版本条目。
+工作流会先运行 `tools/extract_data.py --check` 与 `tests/validate_skill.py`，任一失败就不发布；
+tag 已存在时跳过，可以安全地重复触发（Actions 页面手动 `Run workflow` 即可重试）。
+
+本地预览某个版本的发布说明：
+
+```bash
+python tools/release_notes.py                 # 当前版本
+python tools/release_notes.py --version 1.1.0
+```
+
 提交前检查 `git diff`，确保没有打包文件、缓存、凭据或无关改动。安全漏洞不要创建公开 Issue，请按 [SECURITY.md](SECURITY.md) 报告。

--- a/README.md
+++ b/README.md
@@ -376,6 +376,10 @@ scripts/
 ├── install.ps1              # Windows 安装器
 ├── install.sh               # macOS/Linux 安装器
 └── sync_docs_table.py       # 由官网数据重建无 JS 回退表格
+tools/
+├── extract_data.py          # 由 frontmatter 与文案目录生成官网数据
+├── site_catalog.json        # 官网双语文案目录
+└── release_notes.py         # 由 CHANGELOG 摘录发布说明
 tests/validate_skill.py      # 无第三方依赖的仓库验证器
 ```
 

--- a/tools/release_notes.py
+++ b/tools/release_notes.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""从 SKILL.md 的 version 和 CHANGELOG.md 生成一次发布所需的元数据。
+
+发布说明必须和仓库里的变更记录一致，所以这里只做“摘录”，不另写文案：
+
+    python tools/release_notes.py --print-version          # 打印当前版本号
+    python tools/release_notes.py --output notes.md         # 写出当前版本的发布说明
+    python tools/release_notes.py --version 1.1.0 --output notes.md
+
+CHANGELOG 里缺少对应版本条目时以非零退出码失败，避免发出一个正文为空的 Release。
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL = REPO_ROOT / "skills" / "computer-repair-skill" / "SKILL.md"
+AGENT = REPO_ROOT / "skills" / "computer-repair-skill" / "agents" / "openai.yaml"
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+CHANGELOG_URL = "https://github.com/88lin/computer-repair-skill/blob/main/CHANGELOG.md"
+SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def read_skill_version() -> str:
+    """读取 SKILL.md frontmatter 的 version，并确认 Agent 元数据没有落后。"""
+    lines = SKILL.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0].strip() != "---":
+        raise SystemExit("SKILL.md 缺少 frontmatter。")
+    try:
+        end = next(i for i, line in enumerate(lines[1:], 1) if line.strip() == "---")
+    except StopIteration:
+        raise SystemExit("SKILL.md 的 frontmatter 未闭合。") from None
+
+    version = ""
+    for line in lines[1:end]:
+        if line.startswith("version:"):
+            version = line.split(":", 1)[1].strip().strip("\"'")
+            break
+    if not SEMVER.match(version):
+        raise SystemExit(f"SKILL.md 的 version 不是语义化版本：{version!r}")
+
+    agent_text = AGENT.read_text(encoding="utf-8")
+    agent_match = re.search(r'(?m)^version:\s*"?([\d.]+)"?', agent_text)
+    agent_version = agent_match.group(1) if agent_match else ""
+    if agent_version != version:
+        raise SystemExit(
+            f"版本号不一致：SKILL.md 是 {version}，agents/openai.yaml 是 {agent_version or '缺失'}。"
+        )
+    return version
+
+
+def extract_section(version: str) -> tuple[str, str]:
+    """取出 CHANGELOG 中该版本的日期和正文。"""
+    text = CHANGELOG.read_text(encoding="utf-8")
+    match = re.search(
+        rf"(?ms)^## \[{re.escape(version)}\][^\n]*?(?:-\s*(\S+))?\n(.*?)(?=^## \[|\Z)",
+        text,
+    )
+    if not match:
+        raise SystemExit(
+            f"CHANGELOG.md 缺少 {version} 的条目；请先补 '## [{version}] - YYYY-MM-DD' 再发布。"
+        )
+    body = match.group(2).strip()
+    if not body:
+        raise SystemExit(f"CHANGELOG.md 中 {version} 的条目为空，不发布空说明。")
+    return match.group(1) or "", body
+
+
+def build_notes(version: str, body: str) -> str:
+    """拼出 Release 正文：先说明版本对应关系，再摘录变更，最后回链变更记录。"""
+    return (
+        f"对应 `SKILL.md` 与 `agents/openai.yaml` 的 `version: {version}`。\n\n"
+        f"{body}\n\n"
+        "---\n\n"
+        f"完整变更记录见 [CHANGELOG.md]({CHANGELOG_URL})。\n"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", help="要发布的版本号，默认取 SKILL.md 的 version")
+    parser.add_argument("--print-version", action="store_true", help="只打印版本号")
+    parser.add_argument("--output", type=Path, help="发布说明的输出路径")
+    args = parser.parse_args()
+
+    version = args.version or read_skill_version()
+    if args.print_version:
+        print(version)
+        return 0
+
+    _, body = extract_section(version)
+    notes = build_notes(version, body)
+    if args.output:
+        args.output.write_text(notes, encoding="utf-8")
+        print(f"已写出 {version} 的发布说明：{args.output}")
+    else:
+        sys.stdout.write(notes)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 目的

`SKILL.md` 的 `version` 改动合入 `main` 后，自动创建 `v<version>` tag 并发布 GitHub Release，说明正文从 `CHANGELOG.md` 对应条目摘录，不再手工操作。

## 组成

**`tools/release_notes.py`** —— 发布说明的单一来源，不另写文案：

- 从 `SKILL.md` frontmatter 读 `version`，并校验 `agents/openai.yaml` 的版本一致；
- 从 `CHANGELOG.md` 摘录 `## [x.y.z]` 条目正文；
- 三种情况以非零退出码失败：版本号不一致、CHANGELOG 缺该条目、条目为空——不会发出正文空白的 Release；
- 也能本地预览：`python tools/release_notes.py --version 1.1.0`。

**`.github/workflows/release.yml`**：

- 触发：`main` 上 `SKILL.md` 或 `CHANGELOG.md` 变化，另有 `workflow_dispatch` 供手动重试；
- **发布前先跑** `tools/extract_data.py --check` 与 `tests/validate_skill.py`，任一失败就不发布；
- **幂等**：先查远端 `refs/tags/v<version>`，已存在就跳过后续所有步骤，重复触发安全；
- 用 annotated tag（`git tag -a`），与已手工发布的 `v1.1.0`、`v1.2.0` 保持一致；
- `permissions: contents: write`，`concurrency` 防止并发重复发布。

## 验证

- 生成器输出与**已发布的 v1.2.0 正文逐字节一致**（用 `gh release view v1.2.0` 比对），说明它复刻了我手工发布时的格式；
- `--version 1.1.0` 能正确摘出历史条目；
- 故障注入：不存在的版本 → 退出码 1 并提示补 CHANGELOG 条目；把 `openai.yaml` 版本改回 1.1.0 → 退出码 1 并指出两处不一致；
- 工作流 YAML 解析通过（7 个步骤，触发条件符合预期）；
- `python tests/validate_skill.py` 通过（64 个 Playbook）。

合并后这个工作流会因为 `CHANGELOG.md` 变化而立即触发一次，届时版本仍是 1.2.0、tag 已存在，预期结果是**跳过并记录日志**——正好当作幂等性的线上验证。

## 文档

`CHANGELOG.md` 增加 `## [Unreleased]` 段记录本次新增；`CONTRIBUTING.md` 补「发布版本」小节说明版本号写在哪两处、如何重试；README 项目结构补上此前缺失的 `tools/`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new release workflow for automating version tagging and GitHub releases based on changes in `SKILL.md` and `CHANGELOG.md`. It also adds new tools for data extraction and documentation generation.

### Detailed summary
- Added `tools/` directory with:
  - `extract_data.py`: Generates website data from `frontmatter` and documentation.
  - `release_notes.py`: Creates release notes from `SKILL.md` and `CHANGELOG.md`.
  - `site_catalog.json`: Bilingual documentation catalog.
- Updated `CHANGELOG.md` to include a new "Unreleased" section detailing the release workflow.
- Enhanced `CONTRIBUTING.md` to specify version consistency checks for releases.
- Created `.github/workflows/release.yml` for automated release tagging and publishing.
- Implemented validation steps before releasing to ensure data integrity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->