### PR TITLE
ci: 第一方 action 升到 v7，消除 Node 20 弃用警告

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # 需要完整历史与已有 tag，才能判断该版本是否已发布。
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -9,7 +9,7 @@ jobs:
   star-history:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # 第三方 Action 固定到 v1.3.5 对应的提交，避免可变标签被重写后引入未审阅代码。
       - uses: carsteneu/mystarhistory@ec82d645a6df185f4d845b33691a6bcdd02f608a # v1.3.5
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## 问题

每次工作流运行都会留下一条弃用注解：

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/setup-python@v5`

`actions/checkout@v4` 与 `actions/setup-python@v5` 的 `action.yml` 仍声明 `using: node20`，GitHub 已强制它们跑在 Node 24 上并给出注解。

## 改动

5 处第一方 action 升到当前最新大版本：`actions/checkout@v4 → v7`（3 处）、`actions/setup-python@v5 → v7`（2 处）。两者的 `action.yml` 均声明 `node24`。

`star-history.yml` 里的 `carsteneu/mystarhistory` **未改动**：它是 Docker action（`using: docker`），没有 Node 运行时，不是警告来源，而且已按 commit SHA 锁定在最新的 v1.3.5。

## 跨版本变更核对

因为是跨 3 个大版本，逐版看过发布说明：

| 版本 | 变更 | 对本仓库的影响 |
|---|---|---|
| checkout v5 | 改用 Node 24 | 无 |
| checkout v6 | 凭据改存到独立文件 | 无（内部实现） |
| checkout v7 | 拦截 `pull_request_target` / `workflow_run` 下的 fork PR 检出；转 ESM | 无（本仓库不使用这两种触发） |
| setup-python v6 | **破坏性**：要求 runner ≥ v2.327.1 | 无（GitHub 托管 runner 早已满足） |
| setup-python v7 | 无值得注意的变更 | 无 |

本仓库只用到 `fetch-depth` 和 `python-version` 两个输入，都是稳定接口。

## 验证

- 三个工作流 YAML 解析通过；
- `python tests/validate_skill.py` 通过；
- 合并后可在 Actions 页确认注解消失。

未加 CHANGELOG 条目：`CHANGELOG.md` 记录的是对外可见变更，CI action 版本属于内部维护。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the versions of GitHub Actions used in the workflow files to ensure compatibility and access to the latest features and fixes.

### Detailed summary
- Updated `actions/checkout` from `v4` to `v7` in:
  - `.github/workflows/validate.yml`
  - `.github/workflows/star-history.yml`
  - `.github/workflows/release.yml`
- Updated `actions/setup-python` from `v5` to `v7` in:
  - `.github/workflows/validate.yml`
  - `.github/workflows/release.yml`
- Set `python-version` to `"3.12"` in `.github/workflows/release.yml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->